### PR TITLE
provide link to online readthedocs specifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
          </ul>
          <li>Institution specific data management/conversion tools</li>
          <ul>
-          <li><a href="https://github.com/dangom/dac2bids">dac2bids</a></li>Conversion tool for the Donders Institute 
+          <li><a href="https://github.com/dangom/dac2bids">dac2bids</a></li>Conversion tool for the Donders Institute
           <li><a href="https://github.com/khanlab/autobids">Autobids from the Centre for Functional and Metabolic Mapping (CFMM) at Western’s Robarts Research Institute</a></li>
          </ul>
          <li>Other Tools</li>
@@ -203,6 +203,8 @@
                     <h2>The BIDS specification (1.1.0)</h2>
                     <p>The BIDS specification is available as a PDF download</p>
                     <a href="bids_spec.pdf" class="btn btn-default btn-lg" onclick="trackOutboundLink('bids_spec.pdf'); return false;">Download BIDS specification</a>
+                    <p>and the latest version can be read online in HTML format</p>
+                    <a href="https://bids-specification.readthedocs.io/en/latest/" class="btn btn-default btn-lg" onclick="trackOutboundLink('https://bids-specification.readthedocs.io/en/latest/'); return false;">Read BIDS specification</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
at the moment online version on readthedocs is not linked to, although it is much more accessible.  