### PR TITLE
[MRG] remove bep006 link, fix contrib link, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you'd like to contribute to the website, please see our [contributing guideli
 ## Contributors
 
 This project follows the [all-contributors][link_all-contributors] specification.
-A list of all current BIDS contributors is available [here][link_bids_spec].
+A list of all current BIDS contributors is available [here][link_contributor-list].
 
 
 [link_bids]: http://bids.neuroimaging.io
@@ -29,4 +29,4 @@ A list of all current BIDS contributors is available [here][link_bids_spec].
 [link_get_involved]: http://bids.neuroimaging.io/#get_involved
 [link_contributing]: https://github.com/bids-standard/bids-website/blob/gh-pages/CONTRIBUTING.md
 [link_all-contributors]: https://github.com/kentcdodds/all-contributors#emoji-key
-[link_bids_spec]: https://docs.google.com/document/d/1HFUkAEE-pB-angVcYe6pf_-fVf4sCpOHKesUvfb8Grc/edit#heading=h.hds2i7ii7hjo
+[link_contributor-list]: https://bids-specification.readthedocs.io/en/latest/99-appendices/01-contributors.html

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
          </ul>
          <li>Institution specific data management/conversion tools</li>
          <ul>
-          <li><a href="https://github.com/dangom/dac2bids">dac2bids</a></li>Conversion tool for the Donders Institute 
+          <li><a href="https://github.com/dangom/dac2bids">dac2bids</a></li>Conversion tool for the Donders Institute
           <li><a href="https://github.com/khanlab/autobids">Autobids from the Centre for Functional and Metabolic Mapping (CFMM) at Western’s Robarts Research Institute</a></li>
          </ul>
          <li>Other Tools</li>
@@ -215,7 +215,7 @@
                 <div class="col-lg-8 col-lg-offset-2">
 				    <h2>Getting started</h2>
 					<p>Read the Starter Kit</p>
-					<a href="https://github.com/INCF/bids-starter-kit" class="btn btn-default btn-lg" onclick="trackOutboundLink('https://github.com/INCF/bids-starter-kit'); return false;">BIDS Starter Kit</a><br /><br /><br />
+					<a href="https://github.com/bids-standard/bids-starter-kit" class="btn btn-default btn-lg" onclick="trackOutboundLink('https://github.com/bids-standard/bids-starter-kit'); return false;">BIDS Starter Kit</a><br /><br /><br />
 					<p>Learn from examples</p>
                     <a href="https://openneuro.org/public/datasets" class="btn btn-default btn-lg" onclick="trackOutboundLink('https://openneuro.org/public/datasets'); return false;">Full Datasets in OpenNeuro.org</a><br /><br />
                     <a href="https://github.com/bids-standard/bids-examples" class="btn btn-default btn-lg" onclick="trackOutboundLink('https://github.com/bids-standard/bids-examples'); return false;">Stripped down datasets on GitHub.org</a><br /><br /><br />
@@ -236,7 +236,6 @@
 		<a href="https://docs.google.com/document/d/1bq5eNDHTb6Nkx3WUiOBgKvLNnaa5OMcGtD0AZ9yms2M/edit" class="btn btn-default btn-lg">Extension Proposal 2 - Models specification</a><br /><br />
 		<a href="https://docs.google.com/document/d/1Wwc4A6Mow4ZPPszDIWfCUCRNstn7d_zzaWPcfcHmgI4/edit" class="btn btn-default btn-lg">Extension Proposal 3 - Common derivatives</a><br /><br />
 		<a href="https://docs.google.com/document/d/15tnn5F10KpgHypaQJNNGiNKsni9035GtDqJzWqkkP6c/edit" class="btn btn-default btn-lg">Extension Proposal 5 - Arterial spin labeling</a><br /><br />
-		<a href="https://docs.google.com/document/d/1ArMZ9Y_quTKXC-jNXZksnedK2VHHoKP3HCeO5HPcgLE/edit" class="btn btn-default btn-lg">Extension Proposal 6 - Electroencephalography</a><br /><br />
 		<a href="https://docs.google.com/document/d/1mqMLnxVdLwZjDd4ZiWFqjEAmOmfcModA_R535v3eQs0/edit" class="btn btn-default btn-lg">Extension Proposal 9 - Positron Emission Tomography</a><br /><br />
 		<a href="https://docs.google.com/document/d/1qMUkoaXzRMlJuOcfTYNr3fTsrl4SewWjffjMD5Ew6GY/edit" class="btn btn-default btn-lg">Extension Proposal 10 - intracranial Electroencephalography</a><br /><br />
 		<a href="https://docs.google.com/document/d/1YG2g4UkEio4t_STIBOqYOwneLEs1emHIXbGKynx7V0Y/edit" class="btn btn-default btn-lg">Extension Proposal 11 - The structural preprocessing derivatives</a><br /><br />


### PR DESCRIPTION
Since BEP006 is soon merged through https://github.com/bids-standard/bids-specification/pull/108, we should no longer refer to it as a BEP. With this PR, I remove the BEP006 link.

While I was at it, I stumbled over a few minor issues that I fixed.