### PR TITLE
Add fallback to trackOutboundLink

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,12 +40,16 @@
     * using 'navigator.sendBeacon' in browser that support it.
     */
     var trackOutboundLink = function(url) {
-      gtag('event', 'click', {
-        'event_category': 'outbound',
-        'event_label': url,
-        'transport_type': 'beacon',
-        'event_callback': function(){document.location = url;}
-      });
+      if(window.gtag && gtag.loaded) {
+        gtag('event', 'click', {
+             'event_category': 'outbound',
+             'event_label': url,
+             'transport_type': 'beacon',
+             'event_callback': function(){document.location = url;}
+        });
+      } else {
+        document.location = url;
+      }
     }
     </script>
 


### PR DESCRIPTION
External links from [https://bids.neuroimaging.io](https://bids.neuroimaging.io) (e.g. to the starter kit) are not active if the Google Tag Manager code cannot be loaded.  Following the guidelines at [https://hacks.mozilla.org/2016/01/google-analytics-privacy-and-event-tracking/](https://hacks.mozilla.org/2016/01/google-analytics-privacy-and-event-tracking/) this commit adds a fallback to the trackOutboundLink function allowing tracked links to be followed in the event that the gtag object is not available e.g. due to network errors or client tracking protection.

TODO: confirm that tracking still functions with the fallback in place.