### PR TITLE
fix INCF NI taskforce link

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
 
     <!-- Google Search Console validation -->
     <meta name="google-site-verification" content="EJe8DBmcqboWx67-UuERd0iac52sUYiu_W3W6sZ_3bI" />
-	
+
 <!-- Favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="/BIDS_favicon.ico/apple-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="/BIDS_favicon.ico/apple-icon-60x60.png">
@@ -94,8 +94,8 @@
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">
-	
-	
+
+
 </head>
 
 <body id="page-top" data-spy="scroll" data-target=".navbar-fixed-top">
@@ -278,13 +278,13 @@
                 <h2>Get involved in making BIDS better</h2>
                 <p>We are using GitHub for development and communications. You can start discussions by opening Issues and propose changes via Pull Requests</p>
 		<a href="https://github.com/bids-standard/bids-specification" class="btn btn-default btn-lg">BIDS on GitHub</a><br /><br />
-		    
+
 		<p>Want to extend BIDS to a new modality or set of data types? <br />Draft a BIDS Extension Proposal (BEP) following the BIDS Contributor Guide</p>
 		<a href="https://docs.google.com/document/d/1pWmEEY-1-WuwBPNy5tDAxVJYQ9Een4hZJM06tQZg8X4/edit?usp%3Dsharing&sa=D&ust=1537468908724000" class="btn btn-default btn-lg">Extending BIDS</a><br /><br />
 
 		<p>Contribute to ongoing BIDS Extension Proposals</p>
 		<a href="https://bids-specification.readthedocs.io/en/latest/06-extensions.html#bids-extension-proposals" class="btn btn-default btn-lg">BIDS Extension Proposals</a><br /><br />
-		
+
                 <p>Please adhere to our Code of Conduct <br />Thank you for your contributions!</p>
 		<a href="https://github.com/bids-standard/bids-website/blob/gh-pages/CODE_OF_CONDUCT.md" class="btn btn-default btn-lg">BIDS Code of Conduct</a>
 
@@ -296,7 +296,7 @@
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2">
                 <h2>Acknowledgements</h2>
-                <p>This work has been supported by the <a href="http://bids-standard.org/">International Neuroinformatics Coordinating Facility</a> and the <a href="http://wiki.incf.org/mediawiki/index.php/Neuroimaging_Task_Force">Neuroimaging Data Sharing Task Force</a>.</p>
+                <p>This work has been supported by the <a href="http://bids-standard.org/">International Neuroinformatics Coordinating Facility</a> and the <a href="https://web.archive.org/web/20170813183704/http://wiki.incf.org/mediawiki/index.php/Neuroimaging_Task_Force">Neuroimaging Data Sharing Task Force</a>.</p>
             <div class="col-lg-8 col-lg-offset-2"><img src="INCF_badge.png" width="500" heigh="600"</img></div>
 		</div>
         </div>


### PR DESCRIPTION
related to #50 #51 #52 

BTW, I was not successful finding the broken INCF NI Task force link.

Perhaps we can for now just link to this one, from the wayback-machine:

https://web.archive.org/web/20170813183704/http://wiki.incf.org/mediawiki/index.php/Neuroimaging_Task_Force