### PR TITLE
append .html to urls in nav

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -1,18 +1,18 @@
 
 menu:
   - title: ABOUT
-    url: /index
+    url: /index.html
   - title: NEWS
-    url: /news
+    url: /news.html
   - title: BENEFITS
-    url: /benefits
+    url: /benefits.html
   - title: THE SPECIFICATION
-    url: /specification
+    url: /specification.html
   - title: GETTING STARTED
-    url: /getting_started
+    url: /getting_started.html
   - title: GET INVOLVED
-    url: /get_involved
+    url: /get_involved.html
   - title: GOVERNANCE
-    url: /governance
+    url: /governance.html
   - title: ACKNOWLEDGMENTS
-    url: /acknowledgements
+    url: /acknowledgements.html


### PR DESCRIPTION
closes #89 

This fixes our circleci build and should not affect the "in production" website.

You can see for yourself by trying out the following two links. Both work and resolve to the same thing:

- https://bids.neuroimaging.io/index
- https://bids.neuroimaging.io/index.html

