### PR TITLE
[DOC] add community and ecosystem sections

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -11,7 +11,7 @@ With the Brain  Imaging Data Structure (BIDS), we describe a simple and easy to 
 
 ![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-white_1000x477.png){: .center-image }
 
-BIDS is heavily inspired by the format used internally by the OpenfMRI repository (now known as [OpenNeuro.org](http://openneuro.org)).
+BIDS was heavily inspired by the format used internally by the OpenfMRI repository that is now known as [OpenNeuro](https://openneuro.org).
 While working on BIDS we consulted many neuroscientists to make sure it covers most common experiments, but at the same time is intuitive and easy to adopt.
 The specification is intentionally based on simple file formats and folder structures to reflect current lab practices and make it accessible to a wide range of scientists coming from different backgrounds.
 
@@ -21,7 +21,7 @@ BIDS is developed by the community for the community and everybody can [become a
 
 ## Specification vs. Ecosystem
 
-Since the inception of BIDS as a specification on how to organize neuroimaging data, a large ecosystem of tools and ressources has evolved around BIDS.
+Since the inception of the BIDS specification that documents how to organize neuroimaging data, a large ecosystem of tools and ressources has evolved around BIDS.
 
 A few of the key elements of this ecosystem are the [BIDS-validator](https://github.com/bids-standard/bids-validator), to automatically check datasets for adherence to the specification, [OpenNeuro](https://openneuro.org/), as a database for BIDS formatted datasets, and [BIDS-Apps](https://doi.org/10.1371/journal.pcbi.1005209), a collection of portable neuroimaging pipelines that understand BIDS datasets.
 
@@ -31,7 +31,7 @@ With the ongoing development of new tools and ressources it is important to keep
 
 ## Further Information
 
-- Find a good introduction to the BIDS standard in the [paper published in Nature Scientific Data](https://www.nature.com/articles/sdata201644).
+- Good introductions to the BIDS standard can be found in the initial [paper published in Nature Scientific Data](https://www.nature.com/articles/sdata201644), as well as in the follow up papers on specific modalities: [MEG](https://www.nature.com/articles/sdata2018110), [EEG](https://www.nature.com/articles/s41597-019-0104-8), and [iEEG](https://www.nature.com/articles/s41597-019-0105-7).
 
 - Look through some of the community's [presentations on BIDS](https://osf.io/yn93h/).
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -3,16 +3,38 @@
 
 # About BIDS
 
-Neuroimaging experiments result in complicated data that can be arranged in many different ways. So far there is no consensus how to organize and share data obtained in neuroimaging experiments. Even two researchers working in the same lab can opt to arrange their data in a different way. Lack of consensus (or a standard) leads to misunderstandings and time wasted on rearranging data or rewriting scripts expecting certain structure. Here we describe a simple and easy to adopt way of organizing neuroimaging and behavioral data.
+Neuroimaging experiments result in complicated data that can be arranged in many different ways.
+So far there is no consensus how to organize and share data obtained in neuroimaging experiments.
+Even two researchers working in the same lab can opt to arrange their data in a different way.
+Lack of consensus (or a standard) leads to misunderstandings and time wasted on rearranging data or rewriting scripts expecting certain structure.
+With the Brain  Imaging Data Structure (BIDS), we describe a simple and easy to adopt way of organizing neuroimaging and behavioral data.
 
-![](./assets/img/dicom-reorganization-transparent-white_1000x477.png){: .center-image }
+![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-white_1000x477.png){: .center-image }
 
-BIDS is heavily inspired by the format used internally by the OpenfMRI repository (now known as [OpenNeuro.org](http://openneuro.org)). While working on BIDS we consulted many neuroscientists to make sure it covers most common experiments, but at the same time is intuitive and easy to adopt. The specification is intentionally based on simple file formats and folder structures to reflect current lab practices and make it accessible to a wide range of scientists coming from different backgrounds.
+BIDS is heavily inspired by the format used internally by the OpenfMRI repository (now known as [OpenNeuro.org](http://openneuro.org)).
+While working on BIDS we consulted many neuroscientists to make sure it covers most common experiments, but at the same time is intuitive and easy to adopt.
+The specification is intentionally based on simple file formats and folder structures to reflect current lab practices and make it accessible to a wide range of scientists coming from different backgrounds.
 
-Find a good introduction to the BIDS standard in the [paper published in Nature Scientific Data](http://www.nature.com/articles/sdata201644).
+## BIDS is a community effort
 
-Look through some of the community's [presentations on BIDS](https://osf.io/yn93h/).
+BIDS is developed by the community for the community and everybody can [become a part of the community](https://bids.neuroimaging.io/get_involved.html).
 
-Take a look at how the community [uses BIDS](https://medium.com/stanford-center-for-reproducible-neuroscience/bids-usage-survey-results-72637ff039c4).
+## Specification vs. Ecosystem
 
-Sign up to receive occasional [updates by email](https://docs.google.com/forms/d/1ZLi5qRTuX11KGK7qIidSdZvznFoXAqr2wh6003okv-0/edit) and follow BIDS on [Twitter](https://twitter.com/BIDSstandard?ref_src=twsrc%5Etfw).
+Since the inception of BIDS as a specification on how to organize neuroimaging data, a large ecosystem of tools and ressources has evolved around BIDS.
+
+A few of the key elements of this ecosystem are the [BIDS-validator](https://github.com/bids-standard/bids-validator), to automatically check datasets for adherence to the specification, [OpenNeuro](https://openneuro.org/), as a database for BIDS formatted datasets, and [BIDS-Apps](https://doi.org/10.1371/journal.pcbi.1005209), a collection of portable neuroimaging pipelines that understand BIDS datasets.
+
+A non-exhaustive list of further tools can be found in the [Benefits](https://bids.neuroimaging.io/benefits.html) section.
+
+With the ongoing development of new tools and ressources it is important to keep in mind that the BIDS specification remains the standard according to which the entire ecosystem must adhere.
+
+## Further Information
+
+- Find a good introduction to the BIDS standard in the [paper published in Nature Scientific Data](https://www.nature.com/articles/sdata201644).
+
+- Look through some of the community's [presentations on BIDS](https://osf.io/yn93h/).
+
+- Take a look at how the community [uses BIDS](https://medium.com/stanford-center-for-reproducible-neuroscience/bids-usage-survey-results-72637ff039c4).
+
+- Sign up to receive occasional [updates by email](https://docs.google.com/forms/d/1ZLi5qRTuX11KGK7qIidSdZvznFoXAqr2wh6003okv-0/edit) and follow BIDS on [Twitter](https://twitter.com/BIDSstandard?ref_src=twsrc%5Etfw).

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -11,7 +11,7 @@ With the Brain  Imaging Data Structure (BIDS), we describe a simple and easy to 
 
 ![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-white_1000x477.png){: .center-image }
 
-BIDS was heavily inspired by the format used internally by the OpenfMRI repository that is now known as [OpenNeuro](https://openneuro.org).
+BIDS was heavily inspired by the format used internally by the OpenfMRI repository that is now known as [OpenNeuro](https://openneuro.org){:target="_blank"}.
 While working on BIDS we consulted many neuroscientists to make sure it covers most common experiments, but at the same time is intuitive and easy to adopt.
 The specification is intentionally based on simple file formats and folder structures to reflect current lab practices and make it accessible to a wide range of scientists coming from different backgrounds.
 
@@ -23,7 +23,7 @@ BIDS is developed by the community for the community and everybody can [become a
 
 Since the inception of the BIDS specification that documents how to organize neuroimaging data, a large ecosystem of tools and ressources has evolved around BIDS.
 
-A few of the key elements of this ecosystem are the [BIDS-validator](https://github.com/bids-standard/bids-validator), to automatically check datasets for adherence to the specification, [OpenNeuro](https://openneuro.org/), as a database for BIDS formatted datasets, and [BIDS-Apps](https://doi.org/10.1371/journal.pcbi.1005209), a collection of portable neuroimaging pipelines that understand BIDS datasets.
+A few of the key elements of this ecosystem are the [BIDS-validator](https://github.com/bids-standard/bids-validator){:target="_blank"}, to automatically check datasets for adherence to the specification, [OpenNeuro](https://openneuro.org/){:target="_blank"}, as a database for BIDS formatted datasets, and [BIDS-Apps](https://doi.org/10.1371/journal.pcbi.1005209){:target="_blank"}, a collection of portable neuroimaging pipelines that understand BIDS datasets.
 
 A non-exhaustive list of further tools can be found in the [Benefits](https://bids.neuroimaging.io/benefits.html) section.
 
@@ -31,10 +31,10 @@ With the ongoing development of new tools and ressources it is important to keep
 
 ## Further Information
 
-- Good introductions to the BIDS standard can be found in the initial [paper published in Nature Scientific Data](https://www.nature.com/articles/sdata201644), as well as in the follow up papers on specific modalities: [MEG](https://www.nature.com/articles/sdata2018110), [EEG](https://www.nature.com/articles/s41597-019-0104-8), and [iEEG](https://www.nature.com/articles/s41597-019-0105-7).
+- Good introductions to the BIDS standard can be found in the initial [paper published in Nature Scientific Data](https://www.nature.com/articles/sdata201644){:target="_blank"}, as well as in the follow up papers on specific modalities: [MEG](https://www.nature.com/articles/sdata2018110){:target="_blank"}, [EEG](https://www.nature.com/articles/s41597-019-0104-8){:target="_blank"}, and [iEEG](https://www.nature.com/articles/s41597-019-0105-7){:target="_blank"}.
 
-- Look through some of the community's [presentations on BIDS](https://osf.io/yn93h/).
+- Look through some of the community's [presentations on BIDS](https://osf.io/yn93h/){:target="_blank"}.
 
-- Take a look at how the community [uses BIDS](https://medium.com/stanford-center-for-reproducible-neuroscience/bids-usage-survey-results-72637ff039c4).
+- Take a look at how the community [uses BIDS](https://medium.com/stanford-center-for-reproducible-neuroscience/bids-usage-survey-results-72637ff039c4){:target="_blank"}.
 
-- Sign up to receive occasional [updates by email](https://docs.google.com/forms/d/1ZLi5qRTuX11KGK7qIidSdZvznFoXAqr2wh6003okv-0/edit) and follow BIDS on [Twitter](https://twitter.com/BIDSstandard?ref_src=twsrc%5Etfw).
+- Sign up to receive occasional [updates by email](https://docs.google.com/forms/d/1ZLi5qRTuX11KGK7qIidSdZvznFoXAqr2wh6003okv-0/){:target="_blank"} and follow BIDS on [Twitter](https://twitter.com/BIDSstandard?ref_src=twsrc%5Etfw){:target="_blank"}.

--- a/_posts/2020-03-12-Steering-Group-executive-summary,-action-items,-and-minutes.md
+++ b/_posts/2020-03-12-Steering-Group-executive-summary,-action-items,-and-minutes.md
@@ -7,6 +7,7 @@ display: true
 # Steering Group executive summary, action items, and minutes
 
 Date: Thursday February 13, 2020
+
 Attended: Franklin Feingold, Melanie Ganz, Guiomar Niso, Robert Oostenveld, Kirstie Whitaker
 
 <!--more-->
@@ -14,61 +15,50 @@ Attended: Franklin Feingold, Melanie Ganz, Guiomar Niso, Robert Oostenveld, Kirs
 ### Executive Summary
 
 We discussed the channels through which to share updates to the BIDS specification.
-[A GitHub issue](https://github.com/bids-standard/bids-specification/issues/415) was opened to start crowdsourcing and collecting this information.
-We will be using the resulting list of communication channels to share the release of v1.2.2 and to request the final rounds of feedback on the Genetic information extension ([BEP018](https://github.com/bids-standard/bids-specification/pull/395)).
+[A GitHub issue](https://github.com/bids-standard/bids-specification/issues/415){:target="_blank"} was opened to start crowdsourcing and collecting this information.
+We will be using the resulting list of communication channels to share the release of v1.2.2 and to request the final rounds of feedback on the Genetic information extension ([BEP018](https://github.com/bids-standard/bids-specification/pull/395){:target="_blank"}).
 
 We discussed generating an example slide deck that community members can  use (or pick from) when they want to present BIDS.
 
 We discussed considerations for when to open a repository under the BIDS standard organization on GitHub.
-Previously, community members have opened repositories under the BIDS [GitHub organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-organizations) named [`bids-standard`](https://github.com/bids-standard).
+Previously, community members have opened repositories under the BIDS [GitHub organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-organizations){:target="_blank"} named [`bids-standard`](https://github.com/bids-standard){:target="_blank"}.
 We want to codify guidelines to govern this.
-The plan is that there should be multiple people committed to the repository (otherwise it is better under the personal GitHub account), the maintainers should be clearly identifiable (e.g. as a [CODEOWNERS file](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#about-code-owners) at the top level), there should be a code of conduct in the repository that is consistent with that of the BIDS specification, and (as a consequence of the code of conduct) the repository should welcome contributions from others.
+The plan is that there should be multiple people committed to the repository (otherwise it is better under the personal GitHub account), the maintainers should be clearly identifiable (e.g., as a [CODEOWNERS file](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#about-code-owners){:target="_blank"} at the top level), there should be a code of conduct in the repository that is consistent with that of the BIDS specification, and (as a consequence of the code of conduct) the repository should welcome contributions from others.
 
-We want to host another [Community Forum](https://bids.neuroimaging.io/2020/01/02/announcement-community-forum-events.html) (but not too frequent) and potentially a starter kit/demo in the Open Science Room at OHBM.
+We want to host another [Community Forum](https://bids.neuroimaging.io/2020/01/02/announcement-community-forum-events.html){:target="_blank"} (but not too frequent) and potentially a starter kit/demo in the Open Science Room at [OHBM](https://www.humanbrainmapping.org){:target="_blank"}.
 
-Regarding discussions on where to host our historical specification pdfs (please refer to issue [#407](https://github.com/bids-standard/bids-specification/pull/407)), we consider Zenodo to be a suitable location to store our specification pdfs.
+Regarding discussions on where to host our historical specification pdfs (please refer to issue [#407](https://github.com/bids-standard/bids-specification/pull/407){:target="_blank"}), we consider [Zenodo](https://zenodo.org/){:target:"_blank"} to be a suitable location to store our specification pdfs.
 
 ### Action Items
 
-| Action Item |
-| -------- |
-| Codify rules for making a repo under BIDS standard     |
-| Action items continued |
-| Share meeting executive summary, minutes, and action items on website |
-| KW item: getting time in OSR for BIDS community forum and starter kit |
-| Compile list of channels to share BIDS related information on |
-| Send v1.2.2 release and genetic information call to distribution list |
+- Codify rules for making a repo under BIDS standard
+- Share meeting executive summary, minutes, and action items on website
+- KW item: getting time in OSR for BIDS community forum and starter kit
+- Compile list of channels to share BIDS related information on
+- Send v1.2.2 release and genetic information call to distribution list
 
 ### Minutes
 
-Discussed channels to share BIDS related information
--   FreeSurfer, FSL, SPM, BIDS website-news
-
-Items to share
--   1.2.2 release
--   [BEP018: Genetic information](https://github.com/bids-standard/bids-specification/pull/395)
-  -   Do final call before merging into the standard
-
-Making the standard slide deck
--   make it longer and presenter can slim down as needed
-
-Making repositories in BIDS standard
--   BEP leads in control of their repository
--   Follow our [code of conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md) and [governance document](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/edit)
--   Keeping it reasonable lenient
--   Within README for repository
- -  identify at least 2-3 owners/maintainers of the repository
-
-Set a BIDS community forum and starter kit training in Open Science Room at OHBM
--   Starter kit - running demos showing power of getting data into the BIDS ecosystem
-
-Zenodo for storing historical pdfs
--   Pdfs need to be discoverable and persistent
-
-Add to previous language to BIDS website specification tab
--   add a line pointing to Zenodo
-
-Add to release process
--   adding pdf build to zenodo
-
-BIDS website start drop down menus extension
+- Discussed channels to share BIDS related information
+    -   FreeSurfer, FSL, SPM, BIDS website-news
+- Items to share
+    -   1.2.2 release
+    -   [BEP018: Genetic information](https://github.com/bids-standard/bids-specification/pull/395){:target="_blank"}
+        -   Do final call before merging into the standard
+- Making the standard slide deck
+    -   make it longer and presenter can slim down as needed
+- Making repositories in BIDS standard
+    -   BEP leads in control of their repository
+    -   Follow our [code of conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"} and [governance document](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/){:target="_blank"}
+    -   Keeping it reasonable lenient
+    -   Within README for repository
+    -  identify at least 2-3 owners/maintainers of the repository
+- Set a BIDS community forum and starter kit training in Open Science Room at OHBM
+    -   Starter kit - running demos showing power of getting data into the BIDS ecosystem
+- Zenodo for storing historical pdfs
+    -   Pdfs need to be discoverable and persistent
+- Add to previous language to BIDS website specification tab
+    -   add a line pointing to Zenodo
+- Add to release process
+    -   adding pdf build to zenodo
+- BIDS website start drop down menus extension


### PR DESCRIPTION
This PR addresses a request to distinguish between the BIDS specification and its ecosystem @franklin-feingold 

what I did:

- Put each sentence on its own line ... no line breaks within a sentence --> This will make inspection of the diff much easier in the future
- added a short section stating that we are an open community
- added section to distinguish BIDS specification vs. ecosystem
- put link info from bottom into its own section and turn it into list

