### PR TITLE
CI: add linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
     lint:
         docker:
-            - image: node:8.10.0
+            - image: circleci/node:stretch
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
                 name: lint the markdown files
                 # for defining .remarkrc, see https://github.com/remarkjs/remark-lint#configuring-remark-lint
                 command: |
-                    remark --version
+                    ./node_modules/.bin/remark --version
                     cat .remarkrc
-                    remark _pages _posts --frail --rc-path .remarkrc
+                    ./node_modules/.bin/remark _pages _posts --frail --rc-path .remarkrc
 
     build:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ jobs:
             - run:
                 name: install linter
                 command: |
-                    npm init -y
-                    npm install --save `cat npm-requirements.txt`
+                    npm install `cat npm-requirements.txt`
             - run:
                 name: lint the markdown files
                 # for defining .remarkrc, see https://github.com/remarkjs/remark-lint#configuring-remark-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,11 @@ jobs:
                     npm install --save `cat npm-requirements.txt`
             - run:
                 name: lint the markdown files
+                # for defining .rmarkrc, see https://github.com/remarkjs/remark-lint#configuring-remark-lint
                 command: |
-                    remark --version
+                    npm run remark --version
                     cat .remarkrc
-                    remark _pages _posts --frail --rc-path .remarkrc
+                    npm run remark _pages _posts --frail --rc-path .remarkrc
 
     build:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ jobs:
             - run:
                 name: lint the markdown files
                 command: |
-                    remark ./_pages ./_posts --frail
+                    remark --version
+                    cat .remarkrc
+                    remark _pages _posts --frail --rc-path .remarkrc
 
     build:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,11 @@ jobs:
             - run:
                 name: install linter
                 command: |
-                    npm i -g remark-cli remark-preset-lint-recommended
+                    npm install `cat npm-requirements.txt`
             - run:
                 name: lint the markdown files
                 command: |
-                    remark .
+                    remark . --frail
 
     build:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
             - run:
                 name: install linter
                 command: |
-                    npm install -g `cat npm-requirements.txt`
+                    sudo npm install --global `cat npm-requirements.txt`
             - run:
                 name: lint the markdown files
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
                 name: lint the markdown files
                 # for defining .remarkrc, see https://github.com/remarkjs/remark-lint#configuring-remark-lint
                 command: |
-                    npm run remark --version
+                    remark --version
                     cat .remarkrc
-                    npm run remark _pages _posts --frail --rc-path .remarkrc
+                    remark _pages _posts --frail --rc-path .remarkrc
 
     build:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
 
     lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
             - run:
                 name: install linter
                 command: |
-                    npm install `cat npm-requirements.txt`
+                    npm install -g `cat npm-requirements.txt`
             - run:
                 name: lint the markdown files
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - run:
                 name: lint the markdown files
                 command: |
-                    remark . --frail
+                    remark ./_pages ./_posts --frail
 
     build:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,11 @@ jobs:
             - run:
                 name: install linter
                 command: |
+                    npm init -y
                     npm install --save `cat npm-requirements.txt`
             - run:
                 name: lint the markdown files
-                # for defining .rmarkrc, see https://github.com/remarkjs/remark-lint#configuring-remark-lint
+                # for defining .remarkrc, see https://github.com/remarkjs/remark-lint#configuring-remark-lint
                 command: |
                     npm run remark --version
                     cat .remarkrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,39 @@
 version: 2
 jobs:
+
+    lint:
+        docker:
+            - image: node:8.10.0
+        steps:
+            - checkout
+            - run:
+                name: install linter
+                command: |
+                    npm i -g remark-cli remark-preset-lint-recommended
+            - run:
+                name: lint the markdown files
+                command: |
+                    remark .
+
     build:
         docker:
             - image: circleci/ruby:stretch
         steps:
             - checkout
-
             - run:
-                name: install
+                name: install bundler and run it
                 command: |
                     gem install jekyll bundler
                     bundle
-
             - run:
-                name: build
+                name: build the website
                 command: |
                     bundle exec jekyll build --baseurl /0/home/circleci/project/_site
-
             - store_artifacts:
                 path: ~/project/_site
+
+workflows:
+    lint_and_build:
+        jobs:
+            - lint
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
             - run:
                 name: install linter
                 command: |
-                    sudo npm install --global `cat npm-requirements.txt`
+                    npm install --save `cat npm-requirements.txt`
             - run:
                 name: lint the markdown files
                 command: |

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "preset-lint-recommended"
+  ]
+}

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
-    "preset-lint-recommended"
+    "remark-preset-lint-recommended",
+    ["remark-lint-list-item-indent", false]
   ]
 }

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "preset-lint-recommended",
-    ["lint-list-item-indent", false]
+    "remark-preset-lint-recommended",
+    ["remark-lint-list-item-indent", false]
   ]
 }

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "remark-preset-lint-recommended",
-    ["remark-lint-list-item-indent", false]
+    "preset-lint-recommended",
+    ["lint-list-item-indent", false]
   ]
 }

--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -37,7 +37,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [franklin-feingold@gmail.com](mailto:franklin-feingold@gmail.com). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [ffein@stanford.edu](mailto:ffein@stanford.edu). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -37,7 +37,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at krzysztof.gorgolewski@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [franklin-feingold@gmail.com](mailto:franklin-feingold@gmail.com). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -289,10 +289,11 @@ The definition of "representative" will differ depending on the scope of
 the extension and will be reviewed as part of the steering group's final
 approval.
 - BIDS Steering Group final approval.
+
 The Steering Group evaluates:
-  - Sufficiency of community feedback for the scope of the extension
-  - Validator updated to include the Proposed BEP specification
-  - Final review of the integration into the BIDS standard
+- Sufficiency of community feedback for the scope of the extension
+- Validator updated to include the Proposed BEP specification
+- Final review of the integration into the BIDS standard
 
 ## X. Appendix
 
@@ -414,9 +415,9 @@ We prefer questions to be asked via
 [NeuroStars](https://neurostars.org/tags/bids){:target="_blank"} so that others can search
 them and benefit from the answers, but if you do not feel comfortable
 asking your question publicly please email either Franklin Feingold at
-<ffein@stanford.edu> or Stefan Appelhoff at
-<appelhoff@mpib-berlin.mpg.de>. They will repost an anonymised/general
-version of your question on
+[ffein@stanford.edu](mailto:ffein@stanford.edu) or Stefan Appelhoff at
+[appelhoff@mpib-berlin.mpg.de](mailto:appelhoff@mpib-berlin.mpg.de). They will
+repost an anonymised/general version of your question on
 [NeuroStars](https://neurostars.org/tags/bids){:target="_blank"} and answer it there.
 
 There are several resources that can help a new user get started.
@@ -428,7 +429,7 @@ blog](http://reproducibility.stanford.edu/blog/){:target="_blank"} provides tuto
 community survey results.
 
 All BIDS community members are required to follow the [BIDS code of
-conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"}. Please contact Franklin Feingold at <ffein@stanford.edu> if you have any concerns or would like to report a violation.
+conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"}. Please contact Franklin Feingold at [ffein@stanford.edu](mailto:ffein@stanford.edu) if you have any concerns or would like to report a violation.
 
 ### F. Acknowledgements
 This document draws heavily from the [Modern Paradigm for

--- a/_posts/2020-01-02-announcement-community-forum-events.md
+++ b/_posts/2020-01-02-announcement-community-forum-events.md
@@ -6,7 +6,7 @@ display: true
 
 ## Join the first BIDS Community Forum events in January 2020
 
-The [BIDS Steering Group]({% post_url 2019-12-31-meet-the-bids-steering-group %}) are excited to announce two **Community Forums**!
+The [BIDS Steering Group](https://bids.neuroimaging.io/2019/12/31/meet-the-bids-steering-group.html) are excited to announce two **Community Forums**!
 
 Inspired by [town hall meetings](https://en.wikipedia.org/wiki/Town_hall_meeting){:target="_blank"} and the OHBM General Assembly and Feedback Forum, these online events are a space for members of the BIDS community to meet the steering group and to discuss BIDS strategy and vision.
 

--- a/_posts/2020-03-12-Steering-Group-executive-summary,-action-items,-and-minutes.md
+++ b/_posts/2020-03-12-Steering-Group-executive-summary,-action-items,-and-minutes.md
@@ -42,25 +42,25 @@ Regarding discussions on where to host our historical specification pdfs (please
 ### Minutes
 
 - Discussed channels to share BIDS related information
-    -   FreeSurfer, FSL, SPM, BIDS website-news
+  - FreeSurfer, FSL, SPM, BIDS website-news
 - Items to share
-    -   1.2.2 release
-    -   [BEP018: Genetic information](https://github.com/bids-standard/bids-specification/pull/395){:target="_blank"}
-        -   Do final call before merging into the standard
+  - 1.2.2 release
+  - [BEP018: Genetic information](https://github.com/bids-standard/bids-specification/pull/395){:target="_blank"}
+    - Do final call before merging into the standard
 - Making the standard slide deck
-    -   make it longer and presenter can slim down as needed
+  - make it longer and presenter can slim down as needed
 - Making repositories in BIDS standard
-    -   BEP leads in control of their repository
-    -   Follow our [code of conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"} and [governance document](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/){:target="_blank"}
-    -   Keeping it reasonable lenient
-    -   Within README for repository
-    -  identify at least 2-3 owners/maintainers of the repository
+  - BEP leads in control of their repository
+  - Follow our [code of conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"} and [governance document](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/){:target="_blank"}
+  - Keeping it reasonable lenient
+  - Within README for repository
+  - identify at least 2-3 owners/maintainers of the repository
 - Set a BIDS community forum and starter kit training in Open Science Room at OHBM
-    -   Starter kit - running demos showing power of getting data into the BIDS ecosystem
+  - Starter kit - running demos showing power of getting data into the BIDS ecosystem
 - Zenodo for storing historical pdfs
-    -   Pdfs need to be discoverable and persistent
+  - Pdfs need to be discoverable and persistent
 - Add to previous language to BIDS website specification tab
-    -   add a line pointing to Zenodo
+  - add a line pointing to Zenodo
 - Add to release process
-    -   adding pdf build to zenodo
+  - adding pdf build to zenodo
 - BIDS website start drop down menus extension

--- a/_posts/2020-03-23-Steering-Group-executive-summary,-action-items,-and-minutes.md
+++ b/_posts/2020-03-23-Steering-Group-executive-summary,-action-items,-and-minutes.md
@@ -14,13 +14,13 @@ Attended: Franklin Feingold, Melanie Ganz, Guiomar Niso, Robert Oostenveld
 
 ### Executive Summary
 
-We reviewed the action items from the previous two meetings. We discussed the framework for the BIDS community slides and how this information can be formatted and designed for future extensions and derived versions. We will draft an approach for organizing BIDS related meetings to pilot at NRM and OHBM in June. 
+We reviewed the action items from the previous two meetings. We discussed the framework for the BIDS community slides and how this information can be formatted and designed for future extensions and derived versions. We will draft an approach for organizing BIDS related meetings to pilot at NRM and OHBM in June.
 
 We also have a [list of channels](https://docs.google.com/spreadsheets/d/16SAGK3zG93WM2EWuoZDcRIC7ygPc5b7PDNGpFyC3obA/edit#gid=0){:target="_blank"} to share BIDS related information on. The have a plan for handling non-BIDS related information on our channels is to share on our [google group](https://groups.google.com/forum/#!forum/bids-discussion){:target="_blank"}.
 
 The attending members of the Steering Group gave approval for moving forward with completing the [Genetic Information BEP](https://github.com/bids-standard/bids-specification/pull/395){:target="_blank"}. This will solidify the process for incorporating BEPs moving forward. The process will be: 1) merging in the BEP constructed examples to [BIDS-examples](https://github.com/bids-standard/bids-examples){:target="_blank"}, 2) merge the validator extension into [BIDS-validator](https://github.com/bids-standard/bids-validator){:target="_blank"}, and 3) merge the BEP into [BIDS-specification](https://github.com/bids-standard/bids-specification){:target="_blank"}
 
-The Steering Group gave direction on handling author lists on Zenodo - make it a single author: “BIDS Contributors Group” as defined in the [governance document](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/edit){:target="_blank"}. 
+The Steering Group gave direction on handling author lists on Zenodo - make it a single author: “BIDS Contributors Group” as defined in the [governance document](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/edit){:target="_blank"}.
 
 ### Action Items
 
@@ -38,14 +38,14 @@ The Steering Group gave direction on handling author lists on Zenodo - make it a
 ### Minutes
 
 - Reviewed [previous meeting action items](https://bids.neuroimaging.io/2020/03/12/Steering-Group-executive-summary,-action-items,-and-minutes.html#action-items){:target="_blank"}
-    - A [survey](https://docs.google.com/forms/d/e/1FAIpQLSfGjTA-U_1LECRsbuBQ9X7kdi34aEdxTMoWCwwkEgou-qpb4A/viewform){:target="_blank"} with an accompanying [blog post](https://bids.neuroimaging.io/2020/03/20/engage-with-the-bids-ecosystem.html){:target="_blank"} was drafted to evaluate how the community would like to engage with each other, what barriers may exist that makes engaging more challenging, and ways that we can engage colleagues that do not know about BIDS.
-    - Points to consider when designing the infrastructure to support BIDS slides
-        - An important feature is that the BIDS slides will be a living and breathing document shared via Google slides. 
-        - Google slides gives us the ability to: version control, seamless updating capability, and persistant links.
-        - Discussed preserving and separating the core presentation from the derived versions. Ensuring the references of where they have been used.
-            -  Event link or other event details
+  - A [survey](https://docs.google.com/forms/d/e/1FAIpQLSfGjTA-U_1LECRsbuBQ9X7kdi34aEdxTMoWCwwkEgou-qpb4A/viewform){:target="_blank"} with an accompanying [blog post](https://bids.neuroimaging.io/2020/03/20/engage-with-the-bids-ecosystem.html){:target="_blank"} was drafted to evaluate how the community would like to engage with each other, what barriers may exist that makes engaging more challenging, and ways that we can engage colleagues that do not know about BIDS.
+  - Points to consider when designing the infrastructure to support BIDS slides
+    - An important feature is that the BIDS slides will be a living and breathing document shared via Google slides.
+    - Google slides gives us the ability to: version control, seamless updating capability, and persistant links.
+    - Discussed preserving and separating the core presentation from the derived versions. Ensuring the references of where they have been used.
+      -  Event link or other event details
 
-    - Drafting guidelines for how to organize a BIDS event 
+    - Drafting guidelines for how to organize a BIDS event
     - Pilot at NRM and OHBM (June 2020)
 
     - Compiling a [list of channels](https://docs.google.com/spreadsheets/d/16SAGK3zG93WM2EWuoZDcRIC7ygPc5b7PDNGpFyC3obA/edit#gid=0){:target="_blank"} to share BIDS news. Currently for version releases and community feedback calls on BEPs.
@@ -53,22 +53,16 @@ The Steering Group gave direction on handling author lists on Zenodo - make it a
 
 - Attending Steering Group members gave approval to move forward with finalizing the [Genetic Information extension](https://github.com/bids-standard/bids-specification/pull/395){:target="_blank"} and merging into the specification. This will trigger a [v1.3.0 release](https://github.com/bids-standard/bids-specification/pull/435){:target="_blank"} (according to our [release guidelines](https://github.com/bids-standard/bids-specification/blob/master/Release_Guideline.md){:target="_blank"}).
 
-    - For future BEPs, they will submit their examples to [BIDS-examples](https://github.com/bids-standard/bids-examples){:target="_blank"} for review by the Steering Group and confirm the [validator](https://github.com/bids-standard/bids-validator){:target="_blank"} has been extended properly. The BEP leads can leave it as a draft PR. It was determined that opening the PR from a branch of the [BIDS specification repository](https://github.com/bids-standard/bids-specification){:target="_blank"} should be done allowing us to render the extension via ReadTheDocs. 
-        - Genetic Information was in the BEP lead's fork of BIDS-examples (after the meeting a [PR was opened](https://github.com/bids-standard/bids-examples/pull/178){:target="_blank"}).
+  - For future BEPs, they will submit their examples to [BIDS-examples](https://github.com/bids-standard/bids-examples){:target="_blank"} for review by the Steering Group and confirm the [validator](https://github.com/bids-standard/bids-validator){:target="_blank"} has been extended properly. The BEP leads can leave it as a draft PR. It was determined that opening the PR from a branch of the [BIDS specification repository](https://github.com/bids-standard/bids-specification){:target="_blank"} should be done allowing us to render the extension via ReadTheDocs.
+    - Genetic Information was in the BEP lead's fork of BIDS-examples (after the meeting a [PR was opened](https://github.com/bids-standard/bids-examples/pull/178){:target="_blank"}).
 
 - Regarding the [Zenodo authorship](https://github.com/bids-standard/bids-specification/issues/66){:target="_blank"} discussion, the Steering Group considered for the list to either be  first/last+alphabetical order in the middle or a single authored “[BIDS Contributors Group](https://bids.neuroimaging.io/governance.html#bids-contributors-group){:target="_blank"}”.
-    - Decision toward “BIDS Contributors Group” similar to how ADNI does it.
+  - Decision toward “BIDS Contributors Group” similar to how ADNI does it.
 
 
-- The Steering Group discussed where to share non-BIDS related information. 
-    - The consensus was to share on the [bids-discussion](https://groups.google.com/forum/#!forum/bids-discussion){:target="_blank"} Google group channel.
+- The Steering Group discussed where to share non-BIDS related information.
+  - The consensus was to share on the [bids-discussion](https://groups.google.com/forum/#!forum/bids-discussion){:target="_blank"} Google group channel.
 
 - We brainstormed what may be the related initiatives to keep aware of. FF contacted INCF to see if they have information regarding this. Please see the [INCF blog](https://www.incf.org/blogs-list){:target="_blank"}.
 
 - The Steering Group discussed the format for the BIDS Maintainers monthly update. This will be submitted to Slack and added to the next agenda. This will be implemented starting with the March update and will not be retroactive.
-
-
-
-
-
-

--- a/npm-requirements.txt
+++ b/npm-requirements.txt
@@ -1,0 +1,2 @@
+remark-cli
+remark-preset-lint-recommended

--- a/npm-requirements.txt
+++ b/npm-requirements.txt
@@ -1,2 +1,2 @@
-remark-cli
-remark-preset-lint-recommended
+remark-cli@8.0.0
+remark-preset-lint-recommended@4.0.0


### PR DESCRIPTION
closes #82 

I suggest that we use a very soft Markdown linter preset like [remark-preset-lint-recommended](https://github.com/remarkjs/remark-lint/tree/master/packages/remark-preset-lint-recommended), which will ensure that we don't have syntax errors ... yet we can stay a bit more flexible with how we format things (for now).