### PR TITLE
FIX: use artifact redir as GH action

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,1 +1,0 @@
-0/home/circleci/project/_site/index.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,13 @@ jobs:
                   - gem-cache-0-{{ checksum "./Gemfile" }}
 
             - run:
-                name: install bundler and run it
+                name: install
                 command: |
                     gem install jekyll bundler
                     bundle install --path vendor/bundle
 
             - run:
-                name: build the website
+                name: build
                 command: |
                     bundle exec jekyll build --baseurl /0/_site
 
@@ -49,3 +49,9 @@ jobs:
                 key: gem-cache-0-{{ checksum "./Gemfile" }}
                 paths:
                   - vendor/bundle
+
+workflows:
+    lint_and_build:
+        jobs:
+            - lint
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,8 @@ jobs:
             - run:
                 name: build the website
                 command: |
-                    bundle exec jekyll build --baseurl /0/home/circleci/project/_site
-            - store_artifacts:
-                path: ~/project/_site
+                    bundle exec jekyll build
 
-workflows:
-    lint_and_build:
-        jobs:
-            - lint
-            - build
+            - store_artifacts:
+                path: _site
+                destination: _site

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,18 @@ jobs:
             - image: circleci/ruby:stretch
         steps:
             - checkout
+
+            # Restore gem cache to speed up installations
+            - restore_cache:
+                keys:
+                  - gem-cache-0-{{ checksum "./Gemfile" }}
+
             - run:
                 name: install bundler and run it
                 command: |
                     gem install jekyll bundler
-                    bundle
+                    bundle install --path vendor/bundle
+
             - run:
                 name: build the website
                 command: |
@@ -36,3 +43,9 @@ jobs:
             - store_artifacts:
                 path: _site
                 destination: _site
+
+            # Store gem cache
+            - save_cache:
+                key: gem-cache-0-{{ checksum "./Gemfile" }}
+                paths:
+                  - vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             - run:
                 name: build the website
                 command: |
-                    bundle exec jekyll build
+                    bundle exec jekyll build --baseurl /0/_site
 
             - store_artifacts:
                 path: _site

--- a/.github/workflows/artifacts_redirector.yml
+++ b/.github/workflows/artifacts_redirector.yml
@@ -1,0 +1,12 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/_site/index.html
+          circleci-jobs: build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/bids-standard/bids-website.svg?style=shield)](https://circleci.com/gh/bids-standard/bids-website)
+
 # BIDS website
 
 This is the repository for the Brain Imaging Data Structure (BIDS) website that is hosted at <https://bids.neuroimaging.io>.
@@ -16,7 +18,4 @@ The specification is hosted [here](http://bids-specification.readthedocs.io/). T
 
 ## Asking questions about BIDS
 
-If you have questions how to apply BIDS to your dataset, how to use a shared BIDS dataset, or about tools to convert and/or handle BIDS datasets, please see the [getting started](https://bids.neuroimaging.io/getting_started.html) page. 
-
-
-
+If you have questions how to apply BIDS to your dataset, how to use a shared BIDS dataset, or about tools to convert and/or handle BIDS datasets, please see the [getting started](https://bids.neuroimaging.io/getting_started.html) page.


### PR DESCRIPTION
fixes #105 

This PR:
- adds GEM caching for circleci builds, resulting in faster builds
- fixes the artifact redirection GitHub action by implementing it as a proper GitHub Action
  - as a result, the little link listed under "checks" in each PR will work again, and the rendering of the circleci website artifact will be correct

The effect of the GitHub Action will only be in effect after merging this PR. But I tested this extensively on https://github.com/sappelhoff/bids-website

try yourself by clicking on the CIs of the most recent build. See screenshot. Navigate to my fork and click on the colorful round button next to the latest commit:

![image](https://user-images.githubusercontent.com/9084751/78123779-024aa800-740f-11ea-93af-47b9e0ed781c.png)
