### PR TITLE
Revise Specification page to point to both online and PDF versions

### DIFF
--- a/_pages/specification.md
+++ b/_pages/specification.md
@@ -3,4 +3,4 @@
 
 # The BIDS specification
 
-Read the [complete specification](https://bids-specification.readthedocs.io/en/stable/){:target="_blank"} for the Brain Imaging Data Structure.
+The Brain Imaging Data Structure specification can be [browsed online](https://bids-specification.readthedocs.io/en/stable/){:target="_blank"} or [downloaded as PDF](https://doi.org/10.5281/zenodo.3686061).


### PR DESCRIPTION
Revised the one-sentence Specification webpage to refer to both the online and PDF versions.  There are of course many different ways to phrase/cast this... happy to have suggestions on how to improve the edit.

This addresses https://github.com/bids-standard/bids-specification/issues/135#issuecomment-614659807