### PR TITLE
Mattermost announcement

### DIFF
--- a/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
+++ b/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
@@ -10,7 +10,9 @@ BIDS is joining the [BrainHack Mattermost](https://mattermost.brainhack.org/){:t
 
 <!--more-->
 
-We are proud to announce our home for hosting BIDS organization instant messaging: the [BrainHack Mattermost platform](https://mattermost.brainhack.org/){:target:"_blank"}! We have listed below our current set of BIDS channels. We will be establishing several BIDS channels related to: BEP development, community discussions, and more! Check it out and create your own channel! Please be sure the channel name contains `bids` in the title to increase findability.
+We are proud to announce our home for hosting BIDS organization instant messaging: the [BrainHack Mattermost platform](https://mattermost.brainhack.org/){:target:"_blank"}! In the past few years, several BIDS channels have independently been created on Mattermost by the community. The Steering Group and Maintainers Group have choosen to recognize the BrainHack Mattermost as a member of our organizations's official communication suite. This platform will live alongside our other official communication channels: NeuroStars (forum for support questions), mailing list (announcements), and GitHub repositiories (bug reports + feature requests). 
+
+We have listed below our current set of BIDS channels. We will be establishing several BIDS channels related to: BEP development, community discussions, and more! Check it out and create your own channel! Please be sure the channel name contains `bids` in the title to increase findability.
 
 [Mattermost](https://mattermost.com/){:target:"_blank"} is an open-source alternative to Slack. The user interface and experience is very similar to that on Slack. One may join a channel, make a channel, or private message.
 

--- a/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
+++ b/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
@@ -10,7 +10,7 @@ BIDS is joining the [BrainHack Mattermost](https://mattermost.brainhack.org/){:t
 
 <!--more-->
 
-We are proud to announce our home for hosting BIDS organization instant messaging: the [BrainHack Mattermost platform](https://mattermost.brainhack.org/){:target:"_blank"}! In the past few years, several BIDS channels have independently been created on Mattermost by the community. The Steering Group and Maintainers Group have choosen to recognize the BrainHack Mattermost as a member of our organizations's official communication suite. This platform will live alongside our other official communication channels: NeuroStars (forum for support questions), mailing list (announcements), and GitHub repositiories (bug reports + feature requests). 
+We are proud to announce our home for hosting BIDS organization instant messaging: the [BrainHack Mattermost platform](https://mattermost.brainhack.org/){:target:"_blank"}! In the past few years, several BIDS channels have independently been created on Mattermost by the community. The Steering Group and Maintainers Group have choosen to recognize the BrainHack Mattermost as a member of our organizations's official communication suite. This platform will live alongside our other official communication channels: NeuroStars (forum for support questions), mailing list (announcements), Twitter (community news), and GitHub repositories (bug reports + feature requests). 
 
 We have listed below our current set of BIDS channels. We will be establishing several BIDS channels related to: BEP development, community discussions, and more! Check it out and create your own channel! Please be sure the channel name contains `bids` in the title to increase findability.
 

--- a/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
+++ b/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
@@ -10,7 +10,14 @@ BIDS is joining the [BrainHack Mattermost](https://mattermost.brainhack.org/){:t
 
 <!--more-->
 
-We are proud to announce our home for hosting BIDS organization instant messaging: the [BrainHack Mattermost platform](https://mattermost.brainhack.org/){:target:"_blank"}! In the past few years, several BIDS channels have independently been created on Mattermost by the community. The Steering Group and Maintainers Group have choosen to recognize the BrainHack Mattermost as a member of our organizations's official communication suite. This platform will live alongside our other official communication channels: NeuroStars (forum for support questions), mailing list (announcements), Twitter (community news), and GitHub repositories (bug reports + feature requests). 
+We are proud to announce our home for hosting BIDS organization instant messaging: the [BrainHack Mattermost platform](https://mattermost.brainhack.org/){:target:"_blank"}! In the past few years, several BIDS channels have independently been created on Mattermost by the community.
+The Steering Group and Maintainers Group have chosen to recognize the BrainHack Mattermost as a member of our organizations's official communication suite.
+This platform will live alongside our other official communication channels:
+
+-  NeuroStars (forum for support questions)
+-  mailing list (announcements)
+-  Twitter (community news)
+-  and GitHub repositories (bug reports + feature requests). 
 
 We have listed below our current set of BIDS channels. We will be establishing several BIDS channels related to: BEP development, community discussions, and more! Check it out and create your own channel! Please be sure the channel name contains `bids` in the title to increase findability.
 

--- a/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
+++ b/_posts/2020-06-24-Join-the-BIDS-community-on-the-BrainHack-Mattermost.md
@@ -1,0 +1,30 @@
+---
+title: Join the BIDS community on the BrainHack Mattermost
+author: Franklin Feingold
+display: true
+---
+
+# Join the BIDS community on the BrainHack Mattermost
+
+BIDS is joining the [BrainHack Mattermost](https://mattermost.brainhack.org/){:target:"_blank"}!
+
+<!--more-->
+
+We are proud to announce our home for hosting BIDS organization instant messaging: the [BrainHack Mattermost platform](https://mattermost.brainhack.org/){:target:"_blank"}! We have listed below our current set of BIDS channels. We will be establishing several BIDS channels related to: BEP development, community discussions, and more! Check it out and create your own channel! Please be sure the channel name contains `bids` in the title to increase findability.
+
+[Mattermost](https://mattermost.com/){:target:"_blank"} is an open-source alternative to Slack. The user interface and experience is very similar to that on Slack. One may join a channel, make a channel, or private message.
+
+To find our `BIDS` channels, please navigate to Mattermost and click `More...` at the bottom of the `PUBLIC CHANNELS` section. A prompt will pop up enabling you to search for our `BIDS` related channels. If you have any issues, please message Franklin on Mattermost: `@franklin_`.
+
+The [BrainHack project](https://www.brainhack.org/){:target:"_blank"} seeks to bridge the neuroscience and data science communities through hackathons and unconferences. To do this, they convene unique conferences comprised of researchers from around the world with diverse backgrounds and interests to develop our next generation of open source software for neuroscience. These workshops consist of educational activities, along with plenty of development time. If you are interested in learning more please visit [their website](https://www.brainhack.org/){:target:"_blank"}, check out [their paper](https://academic-oup-com.stanford.idm.oclc.org/gigascience/article/5/1/s13742-016-0121-x/2720978){:target:"_blank"}, and take a look at a [step by step guide](https://thewinnower.com/papers/5577-a-step-by-step-guide-for-organizing-open-collaborative-brainhack-events){:target:"_blank"} for organizing a BrainHack yourself. 
+
+We look forward to seeing you on Mattermost!
+
+Current BIDS channels on Mattermost:
+- `bids_derivatives`: conversations around BIDS-Derivatives
+- `bids_eeg`: conversations around bids and eeg data
+- `bids_ieeg`: conversations around bids and ieeg data
+- `bids_meg`: conversations around bids and meg data
+- `bids-starter-kit`: conversations around the [bids-starter-kit](https://github.com/bids-standard/bids-starter-kit)
+- `help_desk-bids`: getting help converting to BIDS
+- `help_desk-bids-apps`: getting help with BIDS-Apps


### PR DESCRIPTION
This PR adds a post announcing our decision to use the BrainHack Mattermost as our instant messaging solution for BIDS. I wanted to take advantage of OHBM for announcing this decision. I listed an initial set of BIDS channels that are currently live. Once I have the grander BIDS Organization - this list will be updated.

Note: There are several channels that are not active or OHBM hackathon projects - I have omitted them.

Note2: Our remark does not like emails. When there is an angle bracket we get this error message `All automatic links must start with a protocol`. When there I use a literal url we get this error message `Don’t use literal URLs without angle brackets`. Separate issue can be to ease our linter, but I think this is an edge case that shouldn't necessarily move the needle toward setting another option. ref: [pr137](https://github.com/bids-standard/bids-website/pull/137)