### PR TITLE
Improve a11y with larger base font size

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -14,6 +14,10 @@
   background-size: 50%;
 }
 
+html {
+  font-size: 16px;
+}
+
 body {
   background-color: $body-bg-color;
 }


### PR DESCRIPTION
Changing the base font size to 16px to improve readability and, therefore, accessibility (a11y).

Related to GH-141, GH-68.