### PR TITLE
Slightly brighter font & changed link color to improve a11y

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -48,6 +48,6 @@ h6 {
 }
 
 a,
-a:hover {
+a:hover, a:focus {
   color: hotpink;
 }

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -18,6 +18,16 @@ body {
   background-color: $body-bg-color;
 }
 
+.main-content,
+.main-content h1,
+.main-content h2,
+.main-content h3,
+.main-content h4,
+.main-content h5,
+.main-content h6 {
+  color: lightgray;
+}
+
 h1 {
   font-size: 2.2rem;
 }

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -47,10 +47,7 @@ h6 {
   font-size: 0.6rem;
 }
 
-a {
-  color: hotpink;
-}
-
+a,
 a:hover {
   color: hotpink;
 }

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -46,3 +46,11 @@ h5 {
 h6 {
   font-size: 0.6rem;
 }
+
+a {
+  color: hotpink;
+}
+
+a:hover {
+  color: hotpink;
+}

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -49,5 +49,5 @@ h6 {
 
 a,
 a:hover, a:focus {
-  color: hotpink;
+  color: #69b3ff;
 }


### PR DESCRIPTION
Related to GH-141, GH-68.

Link color had to be adjusted because links became undifferentiable from ordinary text with the increased brightness.

I don't have great eyesight and these changes, together with #158, make reading through the website **so** much more pleasant for me, without having to manually crank up the zoom level and contrast.

Happy to discuss the color scheme.