### PR TITLE
Justify text in paragraphs

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -64,4 +64,4 @@ p {
   -ms-hyphens: auto;
   -o-hyphens: auto;
   hyphens: auto;
- }
+}

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -55,3 +55,13 @@ a,
 a:hover, a:focus {
   color: #69b3ff;
 }
+
+p {
+  text-align: justify;
+  word-break: break-word;  /* Chrome */
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  -o-hyphens: auto;
+  hyphens: auto;
+ }


### PR DESCRIPTION
Obviously this only produces acceptable results in combination with hyphenation, so enable this too.