### PR TITLE
BIDS-ASL community review post

### DIFF
--- a/_posts/2020-11-02-BIDS-ASL-community-review.md
+++ b/_posts/2020-11-02-BIDS-ASL-community-review.md
@@ -12,9 +12,9 @@ The BIDS community is preparing to merge the ASL (Arterial Spin Labeling) extens
 
 The BIDS community is preparing to merge the ASL (Arterial Spin Labeling) extension. The [updated draft](https://bids-specification--652.org.readthedocs.build/en/652/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#arterial-spin-labeling-perfusion-data){:target="_blank"} is available for review, and comments and suggestions may be submitted on [GitHub](https://github.com/bids-standard/bids-specification/pull/652){:target="_blank"}. The community review will close on Friday (Nov 13th) at 11:59pm PT (pacific time)
 
-This BIDS extension seeks to establish how ASL data and additional metadata are organized within the BIDS structure. This encompasses the ASL sequences provided in the consensus paper [Alsop 2014], including single- and multi-time point pulsed and (pseudo)-continuous ASL. 
+This BIDS extension seeks to establish how ASL data and additional metadata are organized within the BIDS structure. This encompasses the ASL sequences provided in the consensus paper (Alsop 2014), including single- and multi-time point pulsed and (pseudo)-continuous ASL. 
 
-The final review entails a two week period for public commenting, with a possibility of extension for unresolved discussion. Once public comments are concluded, there will be a one week freeze, during which only critical issues will be considered. (For more details on the release protocol, see https://github.com/bids-standard/bids-specification/blob/master/Release_Protocol.md) 
+The final review entails a two week period for public commenting, with a possibility of extension for unresolved discussion. Once public comments are concluded, there will be a one week freeze, during which only critical issues will be considered. (Please see our [release protocol](https://github.com/bids-standard/bids-specification/blob/master/Release_Protocol.md){:target="_blank"} for more details)
 
 We look forward to hearing your feedback!
 The BIDS Team

--- a/_posts/2020-11-02-BIDS-ASL-community-review.md
+++ b/_posts/2020-11-02-BIDS-ASL-community-review.md
@@ -1,0 +1,20 @@
+---
+title: BIDS-ASL community review
+author: Franklin Feingold
+display: true
+---
+
+# BIDS-ASL request for comments - closes on Friday (Nov 13th)
+
+The BIDS community is preparing to merge the ASL (Arterial Spin Labeling) extension.
+
+<!--more-->
+
+The BIDS community is preparing to merge the ASL (Arterial Spin Labeling) extension. The [updated draft](https://bids-specification--652.org.readthedocs.build/en/652/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#arterial-spin-labeling-perfusion-data){:target="_blank"} is available for review, and comments and suggestions may be submitted on [GitHub](https://github.com/bids-standard/bids-specification/pull/652){:target="_blank"}. The community review will close on Friday (Nov 13th) at 11:59pm PT (pacific time)
+
+This BIDS extension seeks to establish how ASL data and additional metadata are organized within the BIDS structure. This encompasses the ASL sequences provided in the consensus paper [Alsop 2014], including single- and multi-time point pulsed and (pseudo)-continuous ASL. 
+
+The final review entails a two week period for public commenting, with a possibility of extension for unresolved discussion. Once public comments are concluded, there will be a one week freeze, during which only critical issues will be considered. (For more details on the release protocol, see https://github.com/bids-standard/bids-specification/blob/master/Release_Protocol.md) 
+
+We look forward to hearing your feedback!
+The BIDS Team


### PR DESCRIPTION
PR initializes the beginning of the BIDS-ASL community review running through November 13