### PR TITLE
Add BIDS-PET community review

### DIFF
--- a/_posts/2021-01-11-BIDS-PET-community-review.md
+++ b/_posts/2021-01-11-BIDS-PET-community-review.md
@@ -12,6 +12,8 @@ The BIDS community is preparing to merge the PET (Positron Emission Tomography) 
 
 We are happy to announce that the Positron emission tomography BIDS extension is finally nearing it’s completion. Hence, we are seeking final community feedback for the PET BIDS standard. We are looking for feedback on GitHub and specifically to the [BIDS-PET extension proposal](https://github.com/bids-standard/bids-specification/pull/633){:target="_blank"}. We have also developed an extension for the [validator](https://github.com/bids-standard/bids-validator/pull/1088){:target="_blank"} and added [PET examples into BIDS examples](https://github.com/bids-standard/bids-examples/tree/bep009_pet){:target="_blank"}.
 
+This BIDS extension seeks to establish how PET data and additional metadata are organized within the BIDS structure. This encompasses the recent guidelines for brain PET data in publications and in archives provided in the consensus paper ([Knudsen et al. 2020](https://journals.sagepub.com/doi/10.1177/0271678X20905433)), including blood and metabolite data.
+
 The final review entails a two week period for public commenting, with a possibility of extension for unresolved discussion. Once public comments are concluded, there will be a one week freeze, during which only critical issues will be considered. (Please see our [release protocol](https://github.com/bids-standard/bids-specification/blob/master/Release_Protocol.md){:target="_blank"} for more details)
 
 We are looking forward to hear from you,

--- a/_posts/2021-01-11-BIDS-PET-community-review.md
+++ b/_posts/2021-01-11-BIDS-PET-community-review.md
@@ -1,0 +1,18 @@
+---
+title: BIDS-PET community review
+author: Melanie Ganz, Martin Norgaard, and Franklin Feingold
+display: true
+---
+
+# BIDS-PET request for comments - closes on Friday (Jan. 22nd)
+
+The BIDS community is preparing to merge the PET (Positron Emission Tomography) extension.
+
+<!--more-->
+
+We are happy to announce that the Positron emission tomography BIDS extension is finally nearing it’s completion. Hence, we are seeking final community feedback for the PET BIDS standard. We are looking for feedback on GitHub and specifically to the [BIDS-PET extension proposal](https://github.com/bids-standard/bids-specification/pull/633){:target="_blank"}. We have also developed an extension for the [validator](https://github.com/bids-standard/bids-validator/pull/1088){:target="_blank"} and added [PET examples into BIDS examples](https://github.com/bids-standard/bids-examples/tree/bep009_pet){:target="_blank"}.
+
+The final review entails a two week period for public commenting, with a possibility of extension for unresolved discussion. Once public comments are concluded, there will be a one week freeze, during which only critical issues will be considered. (Please see our [release protocol](https://github.com/bids-standard/bids-specification/blob/master/Release_Protocol.md){:target="_blank"} for more details)
+
+We are looking forward to hear from you,
+Melanie Ganz (BEP 009 lead) and team


### PR DESCRIPTION
PR initializes the beginning of the BIDS-PET community review running through January 22. 

[1/8 note: Draft due to verbiage regarding PET additions to the specification is being drafted]