### PR TITLE
Add Clinica to the list of available BIDS converters

### DIFF
--- a/_pages/benefits.md
+++ b/_pages/benefits.md
@@ -39,6 +39,7 @@ A description of how to build containerized apps supporting BIDS inputs can be f
 - [MNE-BIDS](http://mne-tools.github.io/mne-bids/){:target="_blank"} (MEG/EEG/iEEG)
 - [EEGLAB](https://sccn.ucsd.edu/eeglab/index.php){:target="_blank"} with [plugin](https://github.com/arnodelorme/bids-matlab-tools){:target="_blank"} (MEG/EEG analysis package)
 - [BrkRaw](https://brkraw.github.io/docs/gs_bids.html){:target="_blank"} (for a preclinical Bruker MRI scanner)
+- [Clinica](https://aramislab.paris.inria.fr/clinica/docs/public/latest/){:target="_blank"}
 
 ## Institution specific data management/conversion tools
 


### PR DESCRIPTION
Clinica provides BIDS [converters](https://aramislab.paris.inria.fr/clinica/docs/public/latest/#dataset-converters-clinica-convert) for several publicly available neuroimaging datasets as well as BIDS dataset management [utilities](https://aramislab.paris.inria.fr/clinica/docs/public/latest/IO/#data-handling-tools).