### PR TITLE
Add list of steering group and maintainers members

### DIFF
--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -1,0 +1,25 @@
+# - group: maintainers
+#   members:
+#     - name:
+#       git:
+#       affiliation:
+#       twitter:
+#       researchgate:
+#       homepage:
+#       city:
+#       bio:
+
+- group: maintainers
+  members:
+    - name: "Stefan Appelhoff"
+      git: "sappelhoff"
+    - name: "Chris Markiewicz"
+      git: "effigies"
+    - name: "Franklin Feingold"
+      git: "franklin-feingold"
+    - name: "Taylor Salo"
+      git: "tsalo"
+    - name: "Rémi Gau"
+      git: "Remi-Gau"
+    - name: "Ross Blair"
+      git: "rwblair"

--- a/_data/steering.yml
+++ b/_data/steering.yml
@@ -1,0 +1,23 @@
+# - group: maintainers
+#   members:
+#     - name:
+#       git:
+#       affiliation:
+#       twitter:
+#       researchgate:
+#       homepage:
+#       city:
+#       bio:
+
+- group: steering
+  members:
+    - name: "Guiomar Niso"
+      git: "guiomar"
+    - name: "Melanie Ganz"
+      git: "melanieganz"
+    - name: "Robert Oostenveld"
+      git: "robertoostenveld"
+    - name: "Russell Poldrack"
+      git: "poldrack"
+    - name: "Kirstie Whitaker"
+      git: "KirstieJane"

--- a/_includes/members_table.html
+++ b/_includes/members_table.html
@@ -1,0 +1,25 @@
+<section>
+  {% for group in include.members %}
+
+  <table>
+    <tr>
+      {% for person in group.members %}
+      <td style="text-align: center; vertical-align: middle">
+        <a href="https://github.com/{{ person.git }}">
+          <img
+            src="https://github.com/{{ person.git }}.png?size=100"
+            width="100px;"
+            alt=""
+          />
+          <br /><sub><b>{{ person.name }}</b></sub
+          ><br />
+        </a>
+      </td>
+      {% endfor %}
+    </tr>
+  </table>
+
+  <br />
+
+  {% endfor %}
+</section>

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -279,7 +279,13 @@ If you need to contact the maintainers on a specific topic you can use the follo
 
 This group consists of individuals who have contributed to the BIDS
 community. Group members are identified on the [BIDS
-contributors](https://bids-specification.readthedocs.io/en/latest/99-appendices/01-contributors.html){:target="_blank"} list, a list that is intended to be inclusive of all forms of engagement with the BIDS community, and that contributors are encouraged to update on the [specification wiki](https://github.com/bids-standard/bids-specification/wiki/Contributors){:target="_blank"}. Engagement can range from writing copy text in the specification to providing feedback on projects such as the [BIDS starter kit](https://github.com/bids-standard/bids-starter-kit){:target="_blank"}.
+contributors](https://bids-specification.readthedocs.io/en/latest/99-appendices/01-contributors.html){:target="_blank"} list, 
+a list that is intended to be inclusive of all forms of engagement with the BIDS community, 
+and that contributors are encouraged to update on the 
+[specification wiki](https://github.com/bids-standard/bids-specification/wiki/Contributors){:target="_blank"}. 
+Engagement can range from writing copy text in the specification 
+to providing feedback on projects such as the 
+[BIDS starter kit](https://github.com/bids-standard/bids-starter-kit){:target="_blank"}.
 
 Members of the BIDS Contributors Group are encouraged to support the
 BIDS specification by supporting the members of the Maintainers Group in
@@ -321,7 +327,8 @@ working and interest groups.
 
 The current BEP Working Groups and their leads can be found in the
 section on [BIDS Extension
-Proposals](https://bids-specification.readthedocs.io/en/stable/06-extensions.html#bids-extension-proposals){:target="_blank"} in the BIDS specification.
+Proposals](https://bids-specification.readthedocs.io/en/stable/06-extensions.html#bids-extension-proposals){:target="_blank"} 
+in the BIDS specification.
 
 ## 4. Governance of the standardization process
 
@@ -393,7 +400,8 @@ and iEEG.
 **BIDS Extension Proposal (BEP)** - A proposal that intends to extend
 BIDS into an unspecified modality or derivative. A BEP is typically led
 by 1-3 individuals with several contributors. The [list of
-BEPs](https://bids.neuroimaging.io/get_involved.html#extending-the-bids-specification){:target="_blank"} can be found elsewhere on this website.
+BEPs](https://bids.neuroimaging.io/get_involved.html#extending-the-bids-specification){:target="_blank"} 
+can be found elsewhere on this website.
 
 **Draft BEP** - The in-progress document, typically in a Google Doc, of
 a BEP. This is dynamic and is grown and maintained at the discretion of
@@ -515,9 +523,12 @@ blog](http://reproducibility.stanford.edu/blog/){:target="_blank"} provides tuto
 community survey results.
 
 All BIDS community members are required to follow the [BIDS code of
-conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"}. Please contact Franklin Feingold at [ffein@stanford.edu](mailto:ffein@stanford.edu) if you have any concerns or would like to report a violation.
+conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"}. 
+Please contact Franklin Feingold at [ffein@stanford.edu](mailto:ffein@stanford.edu) 
+if you have any concerns or would like to report a violation.
 
 ### F. Acknowledgements
+
 This document draws heavily from the [Modern Paradigm for
 Standards](https://open-stand.org/about-us/principles/){:target="_blank"} and from other
 open-source governance documents including:

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -160,40 +160,7 @@ responsibilities.
 
 The current members of the Steering group are:
 
-<table>
-  <tr>
-    <td align="center">
-      <a href="https://github.com/guiomar">
-        <img src="https://github.com/guiomar.png?size=100" alt=""/>
-        <br><sub><b>Guiomar Niso</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/melanieganz">
-        <img src="https://github.com/melanieganz.png?size=100" alt=""/>
-        <br><sub><b>Melanie Ganz</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/robertoostenveld">
-        <img src="https://github.com/robertoostenveld.png?size=100" alt=""/>
-        <br><sub><b>Robert Oostenveld</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/poldrack">
-        <img src="https://github.com/poldrack.png?size=100" alt=""/>
-        <br><sub><b>Russell Poldrack</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/KirstieJane">
-        <img src="https://github.com/KirstieJane.png?size=100" alt=""/>
-        <br><sub><b>Kirstie Whitaker</b></sub><br>
-      </a>
-    </td>        
-  </tr>
-</table>         
+{% include members_table.html members=site.data.steering %}         
 
 ### BEP Working Group
 
@@ -228,46 +195,7 @@ This group submits monthly status summaries to the Steering Group.
 
 The current members of the Maintainers group are:
 
-<table>
-  <tr>
-    <td align="center">
-      <a href="https://github.com/sappelhoff">
-        <img src="https://github.com/sappelhoff.png?size=100" alt=""/>
-        <br><sub><b>Stefan Appelhoff</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/effigies">
-        <img src="https://github.com/effigies.png?size=100" alt=""/>
-        <br><sub><b>Chris Markiewicz</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/franklin-feingold">
-        <img src="https://github.com/franklin-feingold.png?size=100" alt=""/>
-        <br><sub><b>Franklin Feingold</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/tsalo">
-        <img src="https://github.com/tsalo.png?size=100" alt=""/>
-        <br><sub><b>Taylor Salo</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/Remi-Gau">
-        <img src="https://github.com/Remi-Gau.png?size=100" alt=""/>
-        <br><sub><b>Rémi Gau</b></sub><br>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/rwblair">
-        <img src="https://github.com/rwblair.png?size=100" alt=""/>
-        <br><sub><b>Ross Blair</b></sub><br>
-      </a>
-    </td>         
-  </tr>
-</table>  
+{% include members_table.html members=site.data.maintainers %}
 
 If you need to contact the maintainers on a specific topic you can use the following emails:
 

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -158,6 +158,43 @@ Conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF
 The Steering Group may delegate tasks as needed to fulfill its
 responsibilities.
 
+The current members of the Steering group are:
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/guiomar">
+        <img src="https://github.com/guiomar.png?size=100" alt=""/>
+        <br><sub><b>Guiomar Niso</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/melanieganz">
+        <img src="https://github.com/melanieganz.png?size=100" alt=""/>
+        <br><sub><b>Melanie Ganz</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/robertoostenveld">
+        <img src="https://github.com/robertoostenveld.png?size=100" alt=""/>
+        <br><sub><b>Robert Oostenveld</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/poldrack">
+        <img src="https://github.com/poldrack.png?size=100" alt=""/>
+        <br><sub><b>Russell Poldrack</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/KirstieJane">
+        <img src="https://github.com/KirstieJane.png?size=100" alt=""/>
+        <br><sub><b>Kirstie Whitaker</b></sub><br>
+      </a>
+    </td>        
+  </tr>
+</table>         
+
 ### BEP Working Group
 
 A BEP Working Group is established for every BIDS Extension Proposal
@@ -188,6 +225,55 @@ BIDS contributors may self-nominate to become maintainers, with approval
 by a majority vote of current maintainers.
 
 This group submits monthly status summaries to the Steering Group.
+
+The current members of the Maintainers group are:
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/sappelhoff">
+        <img src="https://github.com/sappelhoff.png?size=100" alt=""/>
+        <br><sub><b>Stefan Appelhoff</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/effigies">
+        <img src="https://github.com/effigies.png?size=100" alt=""/>
+        <br><sub><b>Chris Markiewicz</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/franklin-feingold">
+        <img src="https://github.com/franklin-feingold.png?size=100" alt=""/>
+        <br><sub><b>Franklin Feingold</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/tsalo">
+        <img src="https://github.com/tsalo.png?size=100" alt=""/>
+        <br><sub><b>Taylor Salo</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/Remi-Gau">
+        <img src="https://github.com/Remi-Gau.png?size=100" alt=""/>
+        <br><sub><b>Rémi Gau</b></sub><br>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/rwblair">
+        <img src="https://github.com/rwblair.png?size=100" alt=""/>
+        <br><sub><b>Ross Blair</b></sub><br>
+      </a>
+    </td>         
+  </tr>
+</table>  
+
+If you need to contact the maintainers on a specific topic you can use the following emails:
+
+- bids-website and domain ( [Franklin Feingold](mailto:bids.maintenance+website@gmail.com) )
+- twitter account ( [Franklin Feingold](mailto:bids.maintenance+twitter@gmail.com) )
+- youtube account ( [Rémi Gau](mailto:bids.maintenance+youtube@gmail.com) )
 
 ### BIDS Contributors Group
 


### PR DESCRIPTION
fixes #167 

- "layout" was mostly adapted from the one autogenerated by the all contributors bot
- also added the beginning of a list of which maintainers is "responsible" for what and who to contact.

For the email addresses, I am not using our personal addresses but using the "alias" feature of gmail on the bids maintainers gmail.

Might make sense to set up filter on the gmail side to not miss those.

```
- bids-website and domain ( [Franklin Feingold](mailto:bids.maintenance+website@gmail.com) )
- twitter account ( [Franklin Feingold](mailto:bids.maintenance+twitter@gmail.com) )
- youtube account ( [Rémi Gau](mailto:bids.maintenance+youtube@gmail.com) )
```