### PR TITLE
Town Hall 2021 announcement

### DIFF
--- a/_posts/2021-06-15-BIDS-Town-Hall-2021.md
+++ b/_posts/2021-06-15-BIDS-Town-Hall-2021.md
@@ -16,6 +16,6 @@ Come check out our BIDS Town Hall happening on Monday June 21 at 10pm CEST / 4pm
 
 The event link will be disseminated through the [Eventbrite](https://www.eventbrite.com/e/bids-town-hall-2021-tickets-159737297557){:target="_blank"}. The zoom link will be sent out 2 hours prior to the start of the Town Hall. 
 
-Please feel free to reach out to Franklin (ffein@stanford.edu) with any questions.
+Please feel free to reach out to [Franklin](mailto:ffein@stanford.edu) with any questions.
 
 See you there! 

--- a/_posts/2021-06-15-BIDS-Town-Hall-2021.md
+++ b/_posts/2021-06-15-BIDS-Town-Hall-2021.md
@@ -1,0 +1,21 @@
+---
+title: BIDS Town Hall 2021
+author: Franklin Feingold
+display: true
+---
+
+# BIDS Town Hall 2021
+
+Are you interested in learning more about how the BIDS initiative is developing?
+
+Date: Monday, June 21, 2021
+
+<!--more-->
+
+Come check out our BIDS Town Hall happening on Monday June 21 at 10pm CEST / 4pm ET / 1pm PT to hear more about our organizational updates, status updates from several of our BIDS extension proposal (BEP) leads, our community projects, and voice your thoughts about the organizational direction! 
+
+The event link will be disseminated through the [Eventbrite](https://www.eventbrite.com/e/bids-town-hall-2021-tickets-159737297557){:target="_blank"}. The zoom link will be sent out 2 hours prior to the start of the Town Hall. 
+
+Please feel free to reach out to Franklin (ffein@stanford.edu) with any questions.
+
+See you there! 


### PR DESCRIPTION
pull request intends to add our BIDS Town Hall 2021 announcement into our blog section. We will be using Eventbrite for managing the distribution of the zoom link - this is scheduled to happen 2 hours before the event 

edit: linkchecker failed on several files not associated with this PR (appears to be addressed in https://github.com/bids-standard/bids-website/pull/189) - perhaps this PR can get in due to its time sensitivity 