### PR TITLE
rename sections for consistency/style

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -6,10 +6,10 @@ menu:
     url: /news.html
   - title: BENEFITS
     url: /benefits.html
-  - title: THE SPECIFICATION
+  - title: SPECIFICATION
     url: /specification.html
-  - title: GETTING STARTED
-    url: /getting_started.html
+  - title: GET STARTED
+    url: /get_started.html
   - title: GET INVOLVED
     url: /get_involved.html
   - title: GOVERNANCE

--- a/_pages/get_started.md
+++ b/_pages/get_started.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# Getting started
+# Get started
 
 Read the [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit){:target="_blank"} and check out the [tutorials](https://github.com/bids-standard/bids-starter-kit/wiki/Tutorials){:target="_blank"} there.
 


### PR DESCRIPTION
address two low effort but nice to have points from #200 

- "THE SPECIFICATION" --> "SPECIFICATION" in navbar (shorter, and equally nice)
- "GETTING STARTED" --> GET STARTED in navbar (and file name; it's shorter, and parallel with GET INVOLVED)

The remaining points from #200 might require more discussion