### PR TITLE
Extra SAMRI information

### DIFF
--- a/_data/converters.yml
+++ b/_data/converters.yml
@@ -234,8 +234,14 @@
 
     - name: SAMRI
       url: https://github.com/IBT-FMI/SAMRI
+      comment: |
+        Full stack Small Animal MRI data analysis package, including the `bru2bids`
+        repositing pipeline, which can convert Bruker archives to the BIDS format.
+        From the ETH and University of Zurich, with collaboration from MIT and
+        Dartmouth College.
       updated: 2021-11-08
       data_types: small-animal MRI
+      expected_input: Bruker ParaVision, NIfTI
       language: Python, shell
       documentation: https://doi.org/10.3389/fninf.2020.00005
       GUI: false


### PR DESCRIPTION
@sappelhoff 

SAMRI also includes plenty of analysis and preprocessing functions for BIDS archives, and we already have [an article which documents and benchmarks the registration workflow](https://www.sciencedirect.com/science/article/pii/S1053811921006625).
Is there any other place on the website where I could add this?