### PR TITLE
Redirect to new BEP16 repository

### DIFF
--- a/_bep_collection/bep016.md
+++ b/_bep_collection/bep016.md
@@ -1,4 +1,4 @@
 ---
 redirect_to:
-  - https://docs.google.com/document/d/1cQYBvToU7tUEtWMLMwXUCB_T8gebCotE1OczUpMYW60/
+  - https://github.com/bids-standard/bids-bep016
 ---


### PR DESCRIPTION
This is currently redirecting to an older Google doc that states that the BEP has been merged together with the common derivatives, but work still continues in this GitHub repository.