### PR TITLE
General doc updates

### DIFF
--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -15,8 +15,6 @@
       git: "sappelhoff"
     - name: "Chris Markiewicz"
       git: "effigies"
-    - name: "Franklin Feingold"
-      git: "franklin-feingold"
     - name: "Taylor Salo"
       git: "tsalo"
     - name: "Rémi Gau"

--- a/_data/past_maintainers.yml
+++ b/_data/past_maintainers.yml
@@ -1,0 +1,15 @@
+# - group: maintainers
+#   members:
+#     - name:
+#       git:
+#       affiliation:
+#       twitter:
+#       researchgate:
+#       homepage:
+#       city:
+#       bio:
+
+- group: past_maintainers
+  members:
+    - name: "Franklin Feingold"
+      git: "franklin-feingold"

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -29,7 +29,6 @@ initialization](#c-Governance-ratification-and-BIDS-Steering-Group-initializatio
 - [E. Help](#e-help)
 - [F. Acknowledgements](#f-acknowledgements)
 
-
 ## 1. Introduction
 
 This document, *Brain Imaging Data Structure (BIDS): Governance and
@@ -63,23 +62,24 @@ computing field.
 
 The project is a community-driven effort.
 BIDS, originally OBIDS, was initiated during an INCF sponsored data
-sharing working group meeting (January 2015) at Stanford University. It
-was subsequently spearheaded and maintained by Chris Gorgolewski. The
-project is currently managed and maintained by Franklin Feingold, Stefan
-Appelhoff, and the Poldrack Lab at Stanford. BIDS has advanced under the
-direction and effort of contributors, the community of researchers that
-appreciate the value of standardizing neuroimaging data to facilitate
-sharing and analysis. The project is multifaceted, and depends on
-contributors for: specification development and maintenance, [BIDS
-Extension Proposals
-(BEPs)](/get_involved), software tools, [starter
-kits](https://bids-standard.github.io/bids-starter-kit/){:target="_blank"},
-[examples](https://github.com/bids-standard/bids-examples){:target="_blank"}, and general
-discussions. The relevant discussions are located in our [Google
-Group](https://groups.google.com/forum/#!forum/bids-discussion){:target="_blank"}, [GitHub
-organization](https://github.com/bids-standard){:target="_blank"}, and public Google
-Documents (typically associated with an [extension
-proposal](/get_involved)).
+sharing working group meeting (January 2015) at Stanford University.
+It was subsequently spearheaded and maintained by Chris Gorgolewski.
+In the transitional period after Chris Gorgolewski's departure in early 2019
+and before the community's acceptance of the present governance in late 2019,
+the project was managed and maintained by Franklin Feingold, Stefan Appelhoff, and the Poldrack Lab at Stanford.
+BIDS has advanced under the direction and effort of its contributors,
+the community of researchers that appreciate the value of standardizing neuroimaging data to facilitate sharing and analysis.
+The project is multifaceted and depends on contributors for:
+specification development and maintenance,
+[BIDS Extension Proposals (BEPs)](/get_involved),
+software tools,
+[starter kits](https://bids-standard.github.io/bids-starter-kit/){:target="_blank"},
+[examples](https://github.com/bids-standard/bids-examples){:target="_blank"},
+and general discussions.
+The relevant discussions are located in our
+[Google Group](https://groups.google.com/forum/#!forum/bids-discussion){:target="_blank"},
+[GitHub organization](https://github.com/bids-standard){:target="_blank"},
+and public Google Documents (typically associated with an [extension proposal](/get_involved)).
 
 A key component of the BIDS initiative is the collection of associated
 software tools and platforms that facilitate the validation and ease the
@@ -97,7 +97,6 @@ pipelines on validated BIDS datasets, and platforms like
 that the associated software does not fall under the same governance
 structure as BIDS, although the contributor and user base may largely
 overlap.
-
 
 ### B. BIDS Mission Statement
 
@@ -440,9 +439,8 @@ appropriate repository.
 We prefer questions to be asked via
 [NeuroStars](https://neurostars.org/tags/bids){:target="_blank"} so that others can search
 them and benefit from the answers, but if you do not feel comfortable
-asking your question publicly please email either Franklin Feingold at
-[ffein@stanford.edu](mailto:ffein@stanford.edu) or Stefan Appelhoff at
-[appelhoff@mpib-berlin.mpg.de](mailto:appelhoff@mpib-berlin.mpg.de). They will
+asking your question publicly please feel free to email the BIDS maintainers at
+[bids-maintenance@gmail.com](mailto:bids-maintenance@gmail.com). They will
 repost an anonymised/general version of your question on
 [NeuroStars](https://neurostars.org/tags/bids){:target="_blank"} and answer it there.
 
@@ -454,16 +452,16 @@ Center for Reproducible Neuroscience
 blog](http://reproducibility.stanford.edu/blog/){:target="_blank"} provides tutorials and
 community survey results.
 
-All BIDS community members are required to follow the [BIDS code of
-conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"}.
-Please contact Franklin Feingold at [ffein@stanford.edu](mailto:ffein@stanford.edu)
+All BIDS community members are required to follow the
+[BIDS code of conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"}.
+Please contact the BIDS maintainers at [bids-maintenance@gmail.com](mailto:bids-maintenance@gmail.com)
 if you have any concerns or would like to report a violation.
 
 ### F. Acknowledgements
 
-This document draws heavily from the [Modern Paradigm for
-Standards](https://open-stand.org/about-us/principles/){:target="_blank"} and from other
-open-source governance documents including:
+This document draws heavily from the
+[Modern Paradigm for Standards](https://open-stand.org/about-us/principles/){:target="_blank"}
+and from other open-source governance documents including:
 
 - [https://numpy.org/doc/stable/dev/governance/index.html](https://numpy.org/doc/stable/dev/governance/index.html){:target="_blank"}
 - [https://docs.scipy.org/doc/scipy/dev/governance/governance.html](https://docs.scipy.org/doc/scipy/dev/governance/governance.html){:target="_blank"}

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -194,16 +194,22 @@ guide](https://docs.google.com/document/d/11U43QmYVZUVdCxpJeezmYpkHf4sbzWjjN2EIj
 BIDS contributors may self-nominate to become maintainers, with approval
 by a majority vote of current maintainers.
 
-This group submits monthly status summaries to the Steering Group.
+This group submits
+[monthly status summaries](https://github.com/bids-standard/bids-specification/wiki/BIDS-Maintainers-Documents#bids-maintainers-reports){:target="_blank"}
+to the Steering Group.
 
 The current members of the Maintainers group are:
 
 {% include members_table.html members=site.data.maintainers %}
 
+Past members of the Maintainers group are:
+
+{% include members_table.html members=site.data.past_maintainers %}
+
 If you need to contact the maintainers on a specific topic you can use the following emails:
 
-- bids-website and domain ( [Franklin Feingold](mailto:bids.maintenance+website@gmail.com) )
-- twitter account ( [Franklin Feingold](mailto:bids.maintenance+twitter@gmail.com) )
+- bids-website and domain ( [Stefan Appelhoff](mailto:bids.maintenance+website@gmail.com) )
+- twitter account ( [Stefan Appelhoff](mailto:bids.maintenance+twitter@gmail.com) )
 - youtube account ( [Rémi Gau](mailto:bids.maintenance+youtube@gmail.com) )
 
 ### BIDS Contributors Group

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -440,7 +440,7 @@ We prefer questions to be asked via
 [NeuroStars](https://neurostars.org/tags/bids){:target="_blank"} so that others can search
 them and benefit from the answers, but if you do not feel comfortable
 asking your question publicly please feel free to email the BIDS maintainers at
-[bids-maintenance@gmail.com](mailto:bids-maintenance@gmail.com). They will
+[bids.maintenance+question@gmail.com](mailto:bids.maintenance+question@gmail.com). They will
 repost an anonymised/general version of your question on
 [NeuroStars](https://neurostars.org/tags/bids){:target="_blank"} and answer it there.
 
@@ -454,7 +454,7 @@ community survey results.
 
 All BIDS community members are required to follow the
 [BIDS code of conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md){:target="_blank"}.
-Please contact the BIDS maintainers at [bids-maintenance@gmail.com](mailto:bids-maintenance@gmail.com)
+Please contact the BIDS maintainers at [bids.maintenance+coc@gmail.com](mailto:bids.maintenance+coc@gmail.com)
 if you have any concerns or would like to report a violation.
 
 ### F. Acknowledgements

--- a/_posts/2020-12-03-Steering-Group-executive-summary,-action-items,-and-minutes.md
+++ b/_posts/2020-12-03-Steering-Group-executive-summary,-action-items,-and-minutes.md
@@ -27,7 +27,7 @@ This was a joint meeting between the Steering and Maintainers Group. We began th
   - Releasing ASL and most of BEP001
 - Crediting:
   - Maintainership counts as "substantial contributions to the conception of the work" (one of [ICMJE](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html){:target="_blank"} criteria).
-  - Look at [https://casrai.org/credit/](https://casrai.org/credit/){:target="_blank"} for authorship roles
+  - Look at [https://credit.niso.org/](https://credit.niso.org/){:target="_blank"} for authorship roles
     - Roles that are applicable: data curation and software
     - Resources potentially too
   - Include recommended (but not required) text for including Steering/Maintainers as coauthors and description of roles. Requiring credit goes against open values of standard.
@@ -36,5 +36,5 @@ This was a joint meeting between the Steering and Maintainers Group. We began th
   - Add columns to Maintainers table with start date and end date, and self-selection on whether to include on papers if authors think the ex-Maintainer contributed.
   - Authorship credit could be equal among our groups. BEP leads can make the decision.
   - Preference may be a BIDS Maintainers consortia author
-    - [Credit taxonomy](https://casrai.org/credit/){:target="_blank"} could address and report specific contributions
+    - [Credit taxonomy](https://credit.niso.org/){:target="_blank"} could address and report specific contributions
   - To help avoid confusion regarding how to add a corporate author, we may provide a few examples of how it can be done

--- a/_posts/2021-01-14-Steering-Group-executive-summary,-action-items,-and-minutes.md
+++ b/_posts/2021-01-14-Steering-Group-executive-summary,-action-items,-and-minutes.md
@@ -12,7 +12,7 @@ Date: Thursday January 14, 2021
 
 ### Executive Summary
 
-This meeting was primarily spent discussing our approach for crediting the Steering and Maintainers Group in BEP manuscripts. We will be using the [credit taxonomy](https://casrai.org/credit/){:target="_blank"} for helping to recognize contributors. These guidelines can be added to the [BEP lead guidelines](https://docs.google.com/document/d/1pWmEEY-1-WuwBPNy5tDAxVJYQ9Een4hZJM06tQZg8X4/edit){:target="_blank"}. We want to give our community members the opportunity to be credited for their contributions to a BEP.
+This meeting was primarily spent discussing our approach for crediting the Steering and Maintainers Group in BEP manuscripts. We will be using the [credit taxonomy](https://credit.niso.org/){:target="_blank"} for helping to recognize contributors. These guidelines can be added to the [BEP lead guidelines](https://docs.google.com/document/d/1pWmEEY-1-WuwBPNy5tDAxVJYQ9Een4hZJM06tQZg8X4/edit){:target="_blank"}. We want to give our community members the opportunity to be credited for their contributions to a BEP.
 
 ### Action items
 
@@ -28,7 +28,7 @@ This meeting was primarily spent discussing our approach for crediting the Steer
 - Crediting Steering and Maintainer groups
   - Separate Steering and Maintainer group entities
     - Forward thinking and very inclusive
-    - [Credit taxonomy](https://casrai.org/credit/){:target="_blank"}
+    - [Credit taxonomy](https://credit.niso.org/){:target="_blank"}
       - Articulating why they are authors
     - Individual or groups
     - Argument against consortium level authorship


### PR DESCRIPTION
related to doc updates in the spec as well:

- https://github.com/bids-standard/bids-specification/pull/1168


# To Do / discuss

The doc also contains the following:

```
If you need to contact the maintainers on a specific topic you can use the following emails:

- bids-website and domain ( [Franklin Feingold](mailto:bids.maintenance+website@gmail.com) )
- twitter account ( [Franklin Feingold](mailto:bids.maintenance+twitter@gmail.com) )
- youtube account ( [Rémi Gau](mailto:bids.maintenance+youtube@gmail.com) )
 ```

How should we update this? cc @franklin-feingold 

EDIT: I just put my name in there for now.
