### PR TITLE
late, dated back: add post on steering group elections

### DIFF
--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -475,7 +475,7 @@ and from other open-source governance documents including:
 - [https://www.ieee.org/about/corporate/governance/index.html](https://www.ieee.org/about/corporate/governance/index.html){:target="_blank"}
 - [https://www.apache.org/foundation/governance/](https://www.apache.org/foundation/governance/){:target="_blank"}
 - [https://www.niso.org/what-we-do/creating-NISO-standards](https://www.niso.org/what-we-do/creating-NISO-standards){:target="_blank"}
-- [https://predictablynoisy.com/rust-governance](https://predictablynoisy.com/rust-governance){:target="_blank"}
+- [https://chrisholdgraf.com/blog/2018/rust_governance/](https://chrisholdgraf.com/blog/2018/rust_governance/){:target="_blank"}
 - [https://www.seedsforchange.org.uk/consensus](https://www.seedsforchange.org.uk/consensus){:target="_blank"}
 - [https://en.wikipedia.org/wiki/Internet_governance](https://en.wikipedia.org/wiki/Internet_governance){:target="_blank"}
 - [https://www.icann.org/resources/pages/governance/guidelines-en](https://www.icann.org/resources/pages/governance/guidelines-en){:target="_blank"}

--- a/_posts/2022-11-07-BIDS-Steering-Group-Election-2022.md
+++ b/_posts/2022-11-07-BIDS-Steering-Group-Election-2022.md
@@ -1,0 +1,24 @@
+---
+title: BIDS Steering Group election 2022 result
+author: BIDS Maintainers
+display: true
+---
+
+# BIDS Steering Group election 2022
+
+We are excited to announce the results of the BIDS Steering Group election.
+
+Date: Monday, November 7, 2022
+
+<!--more-->
+
+We are pleased to announce that the newest members of the BIDS Steering Group are Cyril Pernet and Yaroslav Halchenko!
+
+Cyril and Yaroslav have been elected to a term lasting from 2023-2025, and are replacing outgoing members Russ Poldrack and Melanie Ganz.
+
+The results of the election may be viewed at https://app.rankedvote.co/contests/24735/BIDS-Steering-Group-Election-2022/25602/results.
+
+Thanks to all contributors for your participation, and congratulations to Cyril and Yaroslav!
+
+Sincerely,
+The BIDS Maintainers


### PR DESCRIPTION
noticed that we hadn't posted about the steering group election here.

I made a post and dated it back ... I think that's good for consistency reasons as we have posts for other elections that happened.

text simply copied from the [original announcement on the mailing list](https://groups.google.com/g/bids-discussion/c/kJ6DiA1uJ7Q)