### PR TITLE
Update phys2bids supported input

### DIFF
--- a/_data/physio_converters.yml
+++ b/_data/physio_converters.yml
@@ -49,6 +49,7 @@
     expected_input:
         - Acqknowledge
         - Labchart
+        - GE physiological files
     language: 
         - Python
     distribution:


### PR DESCRIPTION
Since release 2.8, phys2bids supports GE data.