### PR TITLE
Proposal to make Atlas BEP an official BEP

### DIFF
--- a/_bep_collection/bep038.md
+++ b/_bep_collection/bep038.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - https://docs.google.com/document/d/1RxW4cARr3-EiBEcXjLpSIVidvnUSHE7yJCUY91i5TfM/edit?usp=sharing
+---

--- a/_data/beps.yml
+++ b/_data/beps.yml
@@ -339,3 +339,15 @@
   content:
     - raw
   blocking: None
+
+- number: "038"
+  title: Atlases
+  leads:
+    - name: "[James Kent](mailto:jamesdkent21@gmail.com)"
+    - name: "[Peer Herholz](mailto:herholz.peer@gmail.com)"
+    - name: "[Eugene Duff](mailto:eugene.duff@paediatrics.ox.ac.uk)"
+    - name: "[Anthony Galassi](mailto:anthony.galassi@nih.gov)"
+  update: New BEP, collecting community comments and feedback. All collaborators are welcome.
+  content:
+    - raw
+  blocking: None


### PR DESCRIPTION
This PR and the included commit are intended to make the Atlas BEP an official BEP by assigning it a number and subsequently sharing it with the wider community to follow the BEP development guidelines.