### PR TITLE
Proposal to make dim. reduction-based networks BEP an official BEP

### DIFF
--- a/_bep_collection/bep039.md
+++ b/_bep_collection/bep039.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - https://docs.google.com/document/d/1GTWsj0MFQedXjOaNk6H0or6IDVFyMAysrJ9I4Zmpz2E/edit?usp=sharing
+---

--- a/_data/beps.yml
+++ b/_data/beps.yml
@@ -351,3 +351,16 @@
   content:
     - raw
   blocking: None
+
+- number: "039"
+  title: Dimensionality reduction-based networks
+  leads:
+    - name: "[Arianna Sala](mailto:arianna.sala@uliege.be)"
+    - name: "[Anibal Heinsfeld](mailto:anibalsolon@utexas.edu)"
+    - name: "[Cyrus Eierud](mailto:ceierud@gsu.edu)"
+    - name: "[Franco Pestilli](mailto:pestilli@utexas.edu)"
+    - name: "[Peer Herholz](mailto:herholz.peer@gmail.com)"
+  update: New BEP, collecting community comments and feedback. All collaborators are welcome.
+  content:
+    - raw
+  blocking: None


### PR DESCRIPTION
This PR and the included commit are intended to make the dimensionality reduction-based networks BEP an official BEP by assigning it a number and subsequently sharing it with the wider community to follow the BEP development guidelines.