### PR TITLE
[ENH] Add additional funding/support in acknowledgments

### DIFF
--- a/_pages/acknowledgements.md
+++ b/_pages/acknowledgements.md
@@ -3,6 +3,17 @@
 
 # Acknowledgements
 
-This work has been supported by the [International Neuroinformatics Coordinating Facility](https://www.incf.org/){:target="_blank"}, the [Neuroimaging Data Sharing Task Force](https://web.archive.org/web/20170813183704/http://wiki.incf.org/mediawiki/index.php/Neuroimaging_Task_Force){:target="_blank"}, the Laura and John Arnold Foundation, NIMH Grant R24MH114705, and NSF grant OAC-1760950.
+This work has been directly supported by the 
+[International Neuroinformatics Coordinating Facility](https://www.incf.org/){:target="_blank"},
+the [Neuroimaging Data Sharing Task Force](https://web.archive.org/web/20170813183704/http://wiki.incf.org/mediawiki/index.php/Neuroimaging_Task_Force){:target="_blank"}, 
+the Laura and John Arnold Foundation, 
+NIMH Grant R24MH114705, 
+NSF grant OAC-1760950.
+
+Additionally, BIDS Contributors are able to support maintenance and further development of the standard thanks to support from 
+NIH BRAIN Initiative grant(s) (MH002977, MH117179, MH126699),
+and Novo Nordisk NNF20OC0063277.
+
 
 ![INCF-badge](./assets/img/incf-badge_281x210.png){: .center-image }
+

--- a/_pages/acknowledgements.md
+++ b/_pages/acknowledgements.md
@@ -12,6 +12,7 @@ NSF grant OAC-1760950.
 
 Additionally, BIDS Contributors are able to support maintenance and further development of the standard thanks to support from 
 NIH BRAIN Initiative grant(s) (MH002977, MH117179, MH126699),
+NIH Grant MH109682,
 and Novo Nordisk NNF20OC0063277.
 
 


### PR DESCRIPTION
Adding in sources of funding that have helped support contributors/contributions to BIDS along with direct funding support in `bids.neuorimaging.io/acknowledgements.html`