### PR TITLE
Revert "update bep028 link" to point back to google doc 

### DIFF
--- a/_bep_collection/bep028.md
+++ b/_bep_collection/bep028.md
@@ -1,4 +1,4 @@
 ---
 redirect_to:
-  - https://github.com/bids-standard/bids-specification/pull/487
+  - https://docs.google.com/document/d/1vw3VNDof5cecv2PkFp7Lw_pNUTUo8-m8V4SIdtGJVKs
 ---


### PR DESCRIPTION
This reverts commit 5332c88315240d8b8a0c234aa57b8adffa042f11.

Following advise from @cmaumet , I have closed https://github.com/bids-standard/bids-specification/pull/487 since it got outdated and did not reflect the state of work, thus leading to confusion etc.