### PR TITLE
move bep 02 and 19 to "completed"

### DIFF
--- a/_data/beps.yml
+++ b/_data/beps.yml
@@ -86,15 +86,6 @@
     - derivative
   blocking: None
 
-- number: "019"
-  title: DICOM Metadata
-  leads:
-    - name: Satrajit Ghosh
-  update: Not active. Could be a NIDM extension rather than in BIDS.
-  content:
-    - metadata
-  blocking: None
-
 - number: "020"
   title: Eye Tracking including Gaze Position and Pupil Size
   leads:

--- a/_data/beps.yml
+++ b/_data/beps.yml
@@ -6,20 +6,6 @@
 #   update:
 #   blocking:
 
-- number: "002"
-  title: BIDS Models Specification
-  leads:
-    - name: Tal Yarkoni
-    - name: Chris Markiewcz
-  update: |
-    Reworked structure:
-    - list of steps is now a directed graph,
-    - [Model zoo](https://github.com/bids-standard/model-zoo){:target:'_blank'},
-    - Abstracted transformations, to ease interoperability of implementations.
-  content:
-    - file format
-  blocking: Stat Models released v1.0.0-rc1 in June 2021 - Please review!
-
 - number: "004"
   title: Susceptibility Weighted Imaging (SWI)
   leads:

--- a/_data/beps_other.yml
+++ b/_data/beps_other.yml
@@ -40,6 +40,14 @@
     - raw
   outcome: "Became the [File mapper](https://github.com/DCAN-Labs/file-mapper)."
 
+- number: "019"
+  title: DICOM Metadata
+  leads:
+    - name: Satrajit Ghosh
+  content:
+    - metadata
+  outcome: Closed in favor of possible direct support of DICOM within BIDS (see this [issue](https://github.com/bids-standard/bids-specification/issues/1552) and this [pull request](https://github.com/bids-standard/bids-specification/pull/1551)).
+
 - number: "025"
   title: Medical Imaging Data structure (MIDS)
   leads:

--- a/_data/beps_other.yml
+++ b/_data/beps_other.yml
@@ -1,0 +1,51 @@
+# List BEP that were not merged into the specifications but instead lead to other outcomes:
+#
+# - becoming tools for handling BIDS
+# - having been merged into other BEPs
+# - having been dropped from consideration
+#
+
+# template
+# - number:
+#   title:
+#   leads:
+#     - name:
+#   content:
+#     - raw
+
+- number: "002"
+  title: BIDS Models Specification
+  leads:
+    - name: Tal Yarkoni
+    - name: Chris Markiewcz
+  content:
+    - file format
+  outcome: "Became an [independent specification with validator](https://bids-standard.github.io/stats-models/) to execute statistical models, with minimal configuration and intervention required from the user."
+
+- number: "013"
+  title: Resting state fMRI derivatives
+  leads:
+    - name: Steven Giavasis
+  content:
+    - raw
+  outcome: Merged into BEP012
+
+- number: "015"
+  title: Mapping file
+  leads:
+    - name: Eric Earl
+    - name: Camille Maumet
+    - name: Vasudev Raguram
+  content:
+    - raw
+  outcome: "Became the [File mapper](https://github.com/DCAN-Labs/file-mapper)."
+
+- number: "025"
+  title: Medical Imaging Data structure (MIDS)
+  leads:
+    - name: Jose Manuel
+    - name: Saborit Torres
+    - name: Maria de la Iglesia Vayá
+  content:
+    - raw
+  outcome: Dropped from consideration; smaller parts are potentially to be included into BIDS outside of the BEP

--- a/_includes/beps_others_table.html
+++ b/_includes/beps_others_table.html
@@ -1,0 +1,49 @@
+<section class="converters">
+  <br />
+  <div align="center" class="table-container">
+    <table>
+      <tr>
+        <th>Extension</th>
+        <th>Title</th>
+        <th>Content</th>
+        <th>Lead(s)</th>
+        <th>Outcome</th>
+      </tr>
+
+      {% assign beps = include.beps %}
+
+      {% for bep in beps %}
+        {% assign number = bep.number %}
+        <tr>
+          <td class="bep-number">
+            <a href="{{ site.url }}/bep{{ number }}" target="_blank"
+              >BEP{{ number }}</a
+            >
+          </td>
+          <td class="bep-title">
+            <p>{{ bep.title }}</p>
+          </td>
+          <td class="bep-content">
+            <ul>
+              {% for x in bep.content %}
+              <li>{{ x | markdownify }}</li>
+              {% endfor %}
+            </ul>
+          </td>
+          <td class="bep-leads">
+            <ul>
+              {% for person in bep.leads %}
+              <li>{{ person.name | markdownify }}</li>
+              {% endfor %}
+            </ul>
+          </td>
+          <td class="bep-comment">
+            <p>{{ bep.outcome | markdownify }}</p>
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  </div>
+
+  <br />
+</section>

--- a/_pages/get_involved.md
+++ b/_pages/get_involved.md
@@ -76,8 +76,4 @@ Some proposals that set out to extend the BIDS specification have instead lead t
 
 See the table below:
 
-| Extension label                                                 | Title                                 | Moderators/leads                                          | Outcome                                                                                               |
-| --------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [BEP013](https://bids.neuroimaging.io/bep013){:target:"_blank"} | Resting state fMRI derivatives        | Steven Giavasis                                           | Merged into BEP012                                                                                    |
-| [BEP015](https://bids.neuroimaging.io/bep015){:target:"_blank"} | Mapping file                          | Eric Earl, Camille Maumet, and Vasudev Raguram            | [File mapper](https://github.com/DCAN-Labs/file-mapper){:target:"_blank"}                             |
-| [BEP025](https://bids.neuroimaging.io/bep025){:target:"_blank"} | Medical Imaging Data structure (MIDS) | Jose Manuel, Saborit Torres, and Maria de la Iglesia Vayá | Dropped from consideration; smaller parts are potentially to be included into BIDS outside of the BEP |
+{% include beps_others_table.html beps=site.data.beps_other %}


### PR DESCRIPTION
- closes #323
- closes #328 
- marks BEP002 as completed moved with the "other 'completed'" BEPs with a link to the current bids stats model spec
- uses yml and jekyll "liquid magic" to render the table