### PR TITLE
Add statistical model derivatives BEP

### DIFF
--- a/_bep_collection/bep041.md
+++ b/_bep_collection/bep041.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - https://docs.google.com/document/d/1KHzp-yk8KXvkUIhtN71WU0m4P4kKT9C1yvI-i9_kNeY/edit?usp=sharing
+---

--- a/_data/beps.yml
+++ b/_data/beps.yml
@@ -325,3 +325,12 @@
   content:
     - raw
   blocking: None
+
+- number: "041"
+  title: Statistical Model Derivatives
+  leads:
+    - name: "[Taylor Salo](mailto:salot@pennmedicine.upenn.edu)"
+  update: New BEP, collecting community comments and feedback. All collaborators are welcome.
+  content:
+    - derivative
+  blocking: None


### PR DESCRIPTION
Adds information about the statistical model derivatives BEP to the website, including numbering as BEP041.

Related to https://github.com/bids-standard/bids-specification/issues/887.