### PR TITLE
Remove (now outdated/incomplete) going from Google doc to markdown file

### DIFF
--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -327,7 +327,7 @@ the BIDS channels
 - Use cases and examples clearly illustrated
 
 Upon a successful Draft BEP review, the BEP will be converted from a
-google document to a markdown file and entered as a pull request on the
+Google document to a pull request for the
 [BIDS standard](https://github.com/bids-standard/bids-specification){:target="_blank"}.
 This will enable further community feedback on the Proposed BEP. Tools
 may begin integrating the Proposed BEP specification.


### PR DESCRIPTION
ATM most of the changes might be changes to the schema, not as much to markdown text files. In the future we might acquire some other features (e.g. workflow figures etc) which would also need to be changed. Overall I think we should strive to remove as much of technical aspects from governance principles as possible -- they should be outlined in other documents, such as https://github.com/bids-standard/bids-extensions etc