### PR TITLE
Various little enhancements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -102,7 +102,7 @@ By using this standard you will benefit in the following ways:
 
 -   There are [validation tools](https://github.com/bids-standard/bids-validator) (also available [online](http://bids-standard.github.io/bids-validator/)) that can check your dataset integrity and let you easily spot missing values.
 
-## Further Information
+## Further information
 
 -   Good introductions to the BIDS standard can be found in the initial
    [paper published in Nature Scientific Data](https://www.nature.com/articles/sdata201644),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 ---
-site_name: The brain imaging data structure
+site_name: The Brain Imaging Data Structure (BIDS)
 repo_url: https://github.com/bids-standard/bids-website.git
 site_url: https://bids-website.readthedocs.io
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,8 @@ exclude_docs: |
 nav:
 -   index.md
 -   Standards:
-    -   standards/index.md
+    -   BIDS specification:
+        -   standards/index.md
     -   BIDS schema:
         -   extensions/docs/schema.md
         -   how it works:


### PR DESCRIPTION
I was looking to suggest to improve bids.neuroimaging.io to reference [BIDS models](https://bids-standard.github.io/stats-models/) among specifications and then discovered activity in this branch which pretty much already did that.

Commits are just minor tune ups to improve consistency . I still could not figure out how to make "BIDS Schema" 'section' to become a hyperlink like other sections are. It seems that the trick is to have it `index.md` (not just `schema.md`)?  then may be it would work if we make it `schema/` folder within https://github.com/bids-standard/bids-extensions ?