### PR TITLE
getting involved and completed bep yaml

### DIFF
--- a/data/beps_completed.yml
+++ b/data/beps_completed.yml
@@ -28,8 +28,6 @@
     -   name: Chris Markiewcz
     content:
     -   file format
-    outcome: Became an [independent specification with validator](https://bids-standard.github.io/stats-models/){:target="_blank"} to execute statistical models, with minimal
-        configuration and intervention required from the user.
     google_doc_created: 2016-09
     pull_request_created: 2018-10
     pull_request_merged: 2023-08

--- a/docs/bep/index.md
+++ b/docs/bep/index.md
@@ -1,32 +1,37 @@
 # Get involved in making BIDS better
 
-The easiest way to contribute to BIDS is to ask questions you have about the specification on
-[Neurostars](https://neurostars.org).
-If your question has a
-[bids tag](https://neurostars.org/search?q=tags%3Abids)
+<u>Neurostars Website</u>
+
+- The easiest way to contribute to BIDS is to ask questions you have about the specification on
+[Neurostars](https://neurostars.org){:target="_blank"}.
+- If your question has a
+[bids tag](https://neurostars.org/search?q=tags%3Abids){:target="_blank"}
 it will be much easier for others to find the answer.
+- You can also get involved by _answering_ questions on
+[Neurostars](https://neurostars.org/search?q=tags%3Abids){:target="_blank"}!
 
-You can also get involved by _answering_ questions on
-[Neurostars](https://neurostars.org/search?q=tags%3Abids)!
+<u>Github Issues</u>
 
-You can contribute to the BIDS specification by opening
-[Issues](https://github.com/bids-standard/bids-specification/issues)
+- You can contribute to the BIDS specification by opening
+[Issues](https://github.com/bids-standard/bids-specification/issues){:target="_blank"}
 and proposing changes via
-[Pull Requests](https://github.com/bids-standard/bids-specification/pulls)
+[Pull Requests](https://github.com/bids-standard/bids-specification/pulls){:target="_blank"}
 on
-[GitHub](https://github.com/bids-standard/bids-specification).
-
-To make improvements to the website that you are reading right now, you can also open an
-[Issue](https://github.com/bids-standard/bids-website/issues)
+[GitHub](https://github.com/bids-standard/bids-specification){:target="_blank"}.
+- To make improvements to the website that you are reading right now, you can also open an
+[Issue](https://github.com/bids-standard/bids-website/issues){:target="_blank"}
 and propose changes via Pull Requests at the
-[BIDS website GitHub repository](https://github.com/bids-standard/bids-website).
+[BIDS website GitHub repository](https://github.com/bids-standard/bids-website){:target="_blank"}.
+
+<u> Become a part of the BIDS Community </u>
 
 There are so many ways to help us build this community.
-You could help someone else learn the benefits of BIDS, give a talk in your local organization, or
-[build a BIDS App](https://bids-apps.neuroimaging.io/)!
 
-The only requirement is that everyone who contributes adheres to our
-[BIDS Code of Conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md).
+- You could help someone else learn the benefits of BIDS by giving a talk in your local organization
+-  Or you could work on [building a BIDS App](https://bids-apps.neuroimaging.io/){:target="_blank"}!
+
+<b>The only requirement is that everyone who contributes adheres to our
+[BIDS Code of Conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md).</b>
 
 Thank you for your contributions!
 


### PR DESCRIPTION
- getting involved text organized more easily readable
- edited superfluous info from completed beps yaml. (outcome is evident from BEP02 link and outcome field isn't needed for completed BEPs)