### PR TITLE
[ENH] split tool tables by category

### DIFF
--- a/data/tools/tools.yml
+++ b/data/tools/tools.yml
@@ -1,9 +1,10 @@
 ---
 # - name:
-#   url:
+#   repo_url:
 #   documentation:
 #   language:
 #       -
+#   category: any of (index and query, file handling, data annotation)
 #   description:
 #   distribution:
 #     - name: pypi
@@ -12,65 +13,68 @@
 #       url:
 
 -   name: ancp-bids
-    url: https://github.com/ANCPLabOldenburg/ancp-bids
+    repo_url: https://github.com/ANCPLabOldenburg/ancp-bids
     documentation: https://ancpbids.readthedocs.io/en/latest/
     language:
-    -   python
+    -   Python
+    category: index and query
     description: A Python package to read/write/query/validate BIDS datasets.
     distribution:
     -   name: pypi
         url: https://pypi.org/project/ancpbids/
 
 -   name: babs
-    url: https://github.com/PennLINC/babs
+    repo_url: https://github.com/PennLINC/babs
     documentation: https://pennlinc-babs.readthedocs.io/
     language:
     -   Python
+    category:
     description: BIDS App Bootstrap (BABS) is a reproducible, generalizable, and scalable Python package for BIDS App analysis of large datasets. It uses
         DataLad and adopts FAIRly big framework.
     distribution:
     -   name: pypi
         url: https://pypi.org/project/babs/
 
--   name: BIDSHandler
-    url: https://github.com/Macquarie-MEG-Research/BIDSHandler
-    language:
-    -   Python
-    description: Python module allowing complete manipulation of BIDS data
-
 -   name: bids2table
-    url: https://github.com/childmindresearch/bids2table
+    repo_url: https://github.com/childmindresearch/bids2table
     documentation: https://childmindresearch.github.io/bids2table/bids2table.html
     language:
-    -   python
+    -   Python
+    category: index and query
     description: bids2table is a library for efficiently indexing and querying large-scale BIDS neuroimaging datasets and derivatives.
     distribution:
     -   name: pypi
         url: https://pypi.org/project/bids2table/
 
--   name: bids-cfood
-    url: https://gitlab.indiscale.com/caosdb/src/crawler-cfoods/bids-cfood
-    language:
-    -   Python
-    description: a module to handle BIDS dataset for the caosDB data crawler
-
 -   name: bids2cite
-    url: https://github.com/Remi-Gau/bids2cite
+    repo_url: https://github.com/Remi-Gau/bids2cite
+    documentation: https://bids2cite.readthedocs.io/en/latest/
     language:
     -   Python
+    category: file handling
     description: package to interactively update `dataset_description.json` and generate citation files (for example `datacite.yml`) for BIDS datasets.
 
+-   name: bids-cfood
+    repo_url: https://gitlab.indiscale.com/caosdb/src/crawler-cfoods/bids-cfood
+    language:
+    -   Python
+    category:
+    description: a module to handle BIDS dataset for the caosDB data crawler
+
 -   name: bids-matlab
-    url: https://github.com/bids-standard/bids-matlab
+    repo_url: https://github.com/bids-standard/bids-matlab
+    documentation: https://bids-matlab.readthedocs.io/en/main/
     language:
     -   MATLAB
     -   Octave
+    category: index and query
     description: MATLAB/Octave tools to interact with datasets conforming to the BIDS format
 
 -   name: BIDS-pydantic
-    url: https://github.com/gold-standard-phantoms/bids-pydantic
+    repo_url: https://github.com/gold-standard-phantoms/bids-pydantic
     language:
     -   Python
+    category:
     description: Pulls a specified version of the BIDS schema and creates corresponding Pydantic models, which will provide BIDS data validation using Python
         type annotations. See also [BIDS-pydantic-models](https://pypi.org/project/BIDS-pydantic-models/).
     distribution:
@@ -78,116 +82,141 @@
         url: https://pypi.org/project/BIDS-pydantic/
 
 -   name: bidser
-    url: https://github.com/bbuchsbaum/bidser
+    repo_url: https://github.com/bbuchsbaum/bidser
     documentation: https://bbuchsbaum.github.io/bidser/
     language:
     -   R
+    category: index and query
     description: Working with Brain Imaging Data Structure in R
 
+-   name: BIDSHandler
+    repo_url: https://github.com/Macquarie-MEG-Research/BIDSHandler
+    language:
+    -   Python
+    category: index and query
+    description: Library for loading and manipulating BIDS compatible MEG data
+
 -   name: bids stats model
-    url: https://pypi.org/project/bsmschema/
+    repo_url: https://github.com/bids-standard/stats-models
     documentation: https://bids-standard.github.io/stats-models/index.html
     language:
     -   Python
+    category:
     distribution:
     -   name: pypi
         url: https://pypi.org/project/bsmschema/
     description: Validate BIDS statistical model. To learn more the [BIDS stats model website](https://bids-standard.github.io/stats-models/index.html)
+
+-   name: Brainstorm
+    repo_url: https://github.com/brainstorm-tools/brainstorm3
+    documentation: http://neuroimage.usc.edu/brainstorm/
+    language:
+    -   MATLAB
+    category: analysis
+    description: MEG/EEG analysis package
 
 -   name: Hierarchical Event Descriptors (HED) online tools
     url: https://hedtools.org/hed
     documentation: https://www.hed-resources.org
     language:
     -   wesbite
+    category: data annotation
     description: Online tools for annotation, validation, summary, and assembly of event file contents and annotations.
 
 -   name: Hierarchical Event Descriptors (HED) Python tools
-    url: https://github.com/hed-standard/hed-Python
+    repo_url: https://github.com/hed-standard/hed-Python
     documentation: https://www.hed-resources.org
     language:
     -   Python
+    category: data annotation
     distribution:
     -   name: pypi
         url: https://pypi.org/project/hedtools/
     description: HED libraries supporting schema development as well as annotation, validation, and analysis.
 
--   name: Brainstorm
-    url: http://neuroimage.usc.edu/brainstorm/
-    language:
-    -   MATLAB
-    description: MEG/EEG analysis package
-
 -   name: clpipe
-    url: https://github.com/cohenlabUNC/clpipe
+    repo_url: https://github.com/cohenlabUNC/clpipe
     documentation: https://clpipe.readthedocs.io/en/latest/index.html
     language:
     -   Python
+    category:
     description: streamlined processing pipeline for MRI data centered around BIDS
 
 -   name: cuBIDS
-    url: https://github.com/pennlinc/cubids
+    repo_url: https://github.com/pennlinc/cubids
     documentation: https://cubids.readthedocs.io/en/latest/
     language:
     -   Python
+    category:
     description: a Python package designed to facilitate reproducible curation of neuroimaging BIDS datasets
     distribution:
     -   name: pypi
         url: https://pypi.org/project/cubids/
 
 -   name: File mapper
-    url: https://github.com/DCAN-Labs/file-mapper
+    repo_url: https://github.com/DCAN-Labs/file-mapper
     language:
     -   Python
+    category: file handling
     description: An easy tool to copy/move/symlink files from one directory to the other! Can be used to "convert" dataset to be BIDS compliant.
 
 -   name: GUI dataset description generator
-    url: https://github.com/tolik-g/BIDS
-    documentation:
+    repo_url: https://github.com/tolik-g/BIDS
     language:
     -   Python
+    category: file handling
     description: GUI form that generates `dataset_description.json`
 
 -   name: Lead-DBS
-    url: https://www.lead-dbs.org/
+    repo_url: https://github.com/netstim/leaddbs
+    documentation: https://www.lead-dbs.org/
     language:
     -   MATLAB
-    description: A toolbox facilitating Deep Brain Stimulation electrode reconstructions  and computer simulations supports BIDS conversion and ingestion
+    category: analysis
+    description: A toolbox facilitating Deep Brain Stimulation electrode reconstructions and computer simulations supports BIDS conversion and ingestion
         of BIDS datasets.
 
 -   name: mne-bids
-    url: https://github.com/mne-tools/mne-bids
+    repo_url: https://github.com/mne-tools/mne-bids
     documentation: https://mne.tools/mne-bids/stable/index.html
     language:
     -   Python
+    category: analysis
     description: collection of tools for converting magnetoencephalography (MEG) data into BIDS format, as well as some helper functions for creating the
         folders and metadata needed for a BIDS dataset.
 
 -   name: neurobagel annotate
     url: https://annotate.neurobagel.org/
+    repo_url: https://github.com/neurobagel/annotation_tool
     documentation: https://neurobagel.org/data_prep/
     language:
     -   website
+    category: data annotation
     description: This tool allows you to create a machine readable data dictionary in .json format for a tabular phenotypic file in .tsv format ("Data table").
 
 -   name: neurobagel query
-    url: https://query.neurobagel.org/
-    documentation: https://neurobagel.org/query_tool/
+    url: https://query.neurobagel.org/?node=All
+    repo_url: https://github.com/neurobagel/query-tool
+    documentation: https://neurobagel.org/public_nodes/
     language:
     -   website
+    category:
     description: Neurobagel's query tool is a web interface for searching across a BIDS datasets based on various subject clinical-demographic and imaging
         parameters.
 
 -   name: nipopy
-    url: https://github.com/neurodatascience/nipoppy
-    documentation: https://neurobagel.org/nipoppy/overview/
+    repo_url: https://github.com/nipoppy/nipoppy
+    documentation: https://nipoppy.readthedocs.io/en/latest/
     language:
     -   Python
+    category:
     description: Lightweight neuroimaging workflow manager to help with DICOM to BIDS conversion and running BIDS apps.
 
 -   name: PRFmodel
-    url: https://github.com/vistalab/PRFmodel
+    repo_url: https://github.com/vistalab/PRFmodel
     documentation: https://github.com/vistalab/PRFmodel/wiki
     description: a set of tools to fit population receptive field models to BIDS datasets
+    category: analysis
     distribution:
     -   name: dockerhub
         url:
@@ -198,11 +227,20 @@
         -   https://hub.docker.com/r/garikoitz/prfanalyze-popeye
         -   https://hub.docker.com/r/garikoitz/prfreport
 
--   name: PyBIDS
-    url: https://github.com/bids-standard/pybids
-    documentation:
+-   name: psychopy-bids
+    repo_url: https://gitlab.com/psygraz/psychopy-bids
+    documentation: https://psychopy-bids.readthedocs.io/en/latest/
     language:
     -   Python
+    category:
+    description: A psychopy plugin to help easily output a BIDS dataset, including `events.tsv` and `beh.tsv` files when running experiments with psychopy.
+
+-   name: PyBIDS
+    repo_url: https://github.com/bids-standard/pybids
+    documentation: https://bids-standard.github.io/pybids/
+    language:
+    -   Python
+    category: index and query
     description: Python package to quickly parse / search the components of a BIDS dataset. It also contains functionality for running analyses on your
         data.
     distribution:
@@ -210,21 +248,17 @@
         url: https://pypi.org/project/pybids/
 
 -   name: rbids
-    url: https://github.com/mathesong/rbids
+    repo_url: https://github.com/mathesong/rbids
     language:
     -   R
+    category: index and query
     description: aims to make BIDS datasets more easily accessible for packages written in R
 
 -   name: spm_2_bids
-    url: https://github.com/cpp-lln-lab/spm_2_bids
+    repo_url: https://github.com/cpp-lln-lab/spm_2_bids
     documentation: https://spm-2-bids.readthedocs.io/en/latest/
     language:
     -   MATLAB
     -   Octave
+    category: file handling
     description: a tool convert SPM preprocessed output to BIDS derivatives (trying to follow [BEP12](https://bids.neuroimaging.io/bep012))
-
--   name: psychopy-bids
-    url: https://gitlab.com/psygraz/psychopy-bids/
-    language:
-    -   Python
-    description: A psychopy plugin to help easily output a BIDS dataset, including `events.tsv` and `beh.tsv` files when running experiments with psychopy.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,3 +1,16 @@
 # Tools
 
+There is a rich ecosystem of tools to help you work with BIDS datasets.
+
+There are many [converters](./converters/index.md)
+to help you go from your sourcedata to have a BIDS dataset.
+
+The [BIDS validator](./validator.md) is there to ensure that your BIDS dataset is valid.
+
+You can use the [BIDS apps](./apps/index.md)
+(automated pipelines that can be used as Docker or Apptainer images)
+to process your BIDS datasets.
+
+There are many other [tools](./others.md) to help you work with, edit or curate BIDS datasets.
+
 <meta property="og:title" content="Tools"/>

--- a/docs/tools/others.md
+++ b/docs/tools/others.md
@@ -3,4 +3,34 @@ hide:
 -   toc
 ---
 
+# Tools
+
+## Indexing and querying
+
+These tools help index the content of BIDS datasets and return a listing of files that match a certain query
+(for example "Give me all the files from subject `01` and `13` for datatypes `anat` and `eeg`.")
+
+{{ MACROS___generate_tools_table(file="tools.yml", category="index and query") }}
+
+## File handling
+
+These tools help you work with certain specific BIDS files or may help you rename them.
+
+{{ MACROS___generate_tools_table(file="tools.yml", category="file handling") }}
+
+## Data annotation
+
+These tools make it easier to curate the metadata of your BIDS dataset.
+
+{{ MACROS___generate_tools_table(file="tools.yml", category="data annotation") }}
+
+## Analysis
+
+These packages or toolboxes are BIDS "friendly" and contain functionalities
+that will make your life easeir if you work with BIDS datasets.
+
+{{ MACROS___generate_tools_table(file="tools.yml", category="analysis") }}
+
+## Others
+
 {{ MACROS___generate_tools_table(file="tools.yml") }}

--- a/macros/macros.py
+++ b/macros/macros.py
@@ -30,12 +30,12 @@ def generate_converter_table(file: str) -> str:
     return template.render(include=content[0])
 
 
-def generate_tools_table(file: str) -> str:
+def generate_tools_table(file: str, category=None) -> str:
     input_file = WEBSITE_DATA_DIR / "tools" / file
     content = yaml.load(input_file)
     env = return_jinja_env()
     template = env.get_template("tools_table_md.jinja")
-    return template.render(include=content)
+    return template.render(include=content, category=category)
 
 
 def generate_members_table(file: str) -> str:

--- a/templates/tools_table_md.jinja
+++ b/templates/tools_table_md.jinja
@@ -1,6 +1,26 @@
 
-| Name  | Language | Description |
-| :---: | :------  | :---------- |
+| Name  | Language | Description | Updated |
+| :---: | :------  | :---------- | :-----: |
 {% for tool in include %}
-| [{{ tool.name }}]({{ tool.url }}) | {% for language in tool.language %} {{ language }} <br> {% endfor %} | {{ tool.description }} |
+{# URL to link to #}
+{% if tool.url %}
+    {% set url = tool.url %}
+{% elif tool.documentation %}
+    {% set url = tool.documentation %}
+{% elif tool.repo_url %}
+    {% set url = tool.repo_url %}
+{% endif %}
+{# variables for the last commit badge #}
+{% if tool.repo_url %}
+    {% if "github" in tool.repo_url %}
+        {%  set repo_url = tool.repo_url | replace("https://github.com/", "")  %}
+        {%  set domain = "github" %}
+    {% elif "gitlab" in tool.repo_url %}
+        {%  set repo_url = tool.repo_url | replace("https://gitlab.com/", "")  %}
+        {%  set domain = "gitlab" %}
+    {% endif %}
+{% endif %}
+{% if tool.category == category %}
+| [{{ tool.name }}]({{ url }}) | {% for language in tool.language %} {{ language }} <br> {% endfor %} | {{ tool.description }} | ![Last commit](https://img.shields.io/{{ domain }}/last-commit/{{ repo_url }}?style=plastic) |
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
- closes #450 
- closes #447 
- add last commit badge to the table
- fix missing links to repo, documentation for several tools
- link in table should now be url if specified otherwise documentation, otherwise repo
- try to sort the tools "alphabetically" in the yml