### PR TITLE
[ENH] Add mne-bids-pipeline

### DIFF
--- a/data/tools/tools.yml
+++ b/data/tools/tools.yml
@@ -222,6 +222,14 @@
     category: analysis
     description: collection of tools for converting magnetoencephalography (MEG) data into BIDS format, as well as some helper functions for creating the
         folders and metadata needed for a BIDS dataset.
+        
+-   name: mne-bids-pipeline
+    repo_url: https://github.com/mne-tools/mne-bids-pipeline
+    documentation: https://mne.tools/mne-bids-pipeline/stable/index.html
+    language:
+    -   Python
+    category: analysis
+    description: MNE-BIDS-Pipeline is a full-flegded processing pipeline for your MEG and EEG data. Under the hood, it uses MNE-Python.
 
 -   name: neurobagel annotate
     url: https://annotate.neurobagel.org/


### PR DESCRIPTION
see https://github.com/bids-standard/awesome-bids/pull/52

copy from there:

I would like to add https://mne.tools/mne-bids-pipeline to the list. For me the project was not easily findable, even though I already tinkered with MNE and BIDS for a few days. Including it here might make it more findable.

```
MNE-BIDS-Pipeline is a full-flegded processing pipeline for your MEG and EEG data.

It operates on data stored according to the [Brain Imaging Data Structure (BIDS)](https://bids.neuroimaging.io/).
Under the hood, it uses [MNE-Python](https://mne.tools/).
```