### PR TITLE
Move links from bids-validator to legacy-validator

### DIFF
--- a/docs/blog/posts/2023-02-09-steering-group-minutes.md
+++ b/docs/blog/posts/2023-02-09-steering-group-minutes.md
@@ -241,8 +241,8 @@ examples. See issues below:
 
 Outstanding, but WIP:
 
--   [https://github.com/bids-standard/bids-validator/pull/1578](https://github.com/bids-standard/bids-validator/pull/1578)
--   [https://github.com/bids-standard/bids-validator/issues/1564](https://github.com/bids-standard/bids-validator/issues/1564)
+-   <https://github.com/bids-standard/legacy-validator/pull/1578>
+-   <https://github.com/bids-standard/legacy-validator/issues/1564>
 
 BIDS derivatives meeting : next week the first round of invites will be
 extended, looking for more funding to support travel. Aiming for 20-30

--- a/docs/blog/posts/2023-05-25-steering-group-minutes.md
+++ b/docs/blog/posts/2023-05-25-steering-group-minutes.md
@@ -128,9 +128,9 @@ not been altered.
 
 Add a list of BIDS ignore files:
 
-> [[https://github.com/bids-standard/bids-validator/issues/1676]](https://github.com/bids-standard/bids-validator/issues/1676)
+> <https://github.com/bids-standard/legacy-validator/issues/1676>
 >
-> [[https://github.com/bids-standard/bids-validator/issues/1677]](https://github.com/bids-standard/bids-validator/issues/1677)
+> <https://github.com/bids-standard/legacy-validator/issues/1677>
 
 Should we reach out to the new **Imaging Neuroscience** journal while
 they are still developing their platform?

--- a/docs/blog/posts/community-review-pet.md
+++ b/docs/blog/posts/community-review-pet.md
@@ -12,7 +12,7 @@ The BIDS community is preparing to merge the PET (Positron Emission Tomography) 
 
 1/19 PET community review update: We have extended the community review period to Friday, February 12 at 11:59pm (pacific time).
 
-We are happy to announce that the Positron emission tomography BIDS extension is finally nearing it’s completion. Hence, we are seeking final community feedback for the PET BIDS standard. We are looking for feedback on GitHub and specifically to the [BIDS-PET extension proposal](https://github.com/bids-standard/bids-specification/pull/633). We have also developed an extension for the [validator](https://github.com/bids-standard/bids-validator/pull/1088) and added [PET examples into BIDS examples](https://github.com/bids-standard/bids-examples/).
+We are happy to announce that the Positron emission tomography BIDS extension is finally nearing it’s completion. Hence, we are seeking final community feedback for the PET BIDS standard. We are looking for feedback on GitHub and specifically to the [BIDS-PET extension proposal](https://github.com/bids-standard/bids-specification/pull/633). We have also developed an extension for the [validator](https://github.com/bids-standard/legacy-validator/pull/1088) and added [PET examples into BIDS examples](https://github.com/bids-standard/bids-examples/).
 
 This BIDS extension seeks to establish how PET data and additional metadata are organized within the BIDS structure. This encompasses the recent guidelines for brain PET data in publications and in archives provided in the consensus paper ([Knudsen et al. 2020](https://doi.org/10.1177/0271678X20905433)), including blood and metabolite data.
 

--- a/docs/collaboration/governance.md
+++ b/docs/collaboration/governance.md
@@ -471,7 +471,7 @@ and from other open-source governance documents including:
 -   [https://www.ieee.org/about/corporate/governance/index.html](https://www.ieee.org/about/corporate/governance/index.html)
 -   [https://www.apache.org/foundation/governance/](https://www.apache.org/foundation/governance/)
 -   [https://www.niso.org/what-we-do/creating-NISO-standards](https://www.niso.org/what-we-do/creating-NISO-standards)
--   [https://chrisholdgraf.com/blog/2018/rust_governance/](https://chrisholdgraf.com/blog/2018/rust_governance/)
+-   <https://chrisholdgraf.com/blog/2018/rust-governance>
 -   [https://www.seedsforchange.org.uk/consensus](https://www.seedsforchange.org.uk/consensus)
 -   [https://en.wikipedia.org/wiki/Internet_governance](https://en.wikipedia.org/wiki/Internet_governance)
 -   [https://www.icann.org/resources/pages/governance/guidelines-en](https://www.icann.org/resources/pages/governance/guidelines-en)

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -156,7 +156,7 @@ in the [BIDS Extension Proposals Guide](../extensions/index.md).
 If only part of your data is covered under BIDS,
 an option to allow additional files
 currently not covered in BIDS to pass the validator is
-the [.bidsignore](https://github.com/bids-standard/bids-validator/blob/master/bids-validator/README.md) file,
+the [.bidsignore](https://github.com/bids-standard/legacy-validator/blob/master/bids-validator/README.md) file,
 which works just like [.gitignore](https://git-scm.com/docs/gitignore).
 It allows you to list all the files (or directories, with wildcards)
 that are not BIDS compliant and should be ignored by the validator.

--- a/docs/standards/schema/index.md
+++ b/docs/standards/schema/index.md
@@ -91,7 +91,7 @@ A change now made to a BEP, the spec in general, is now a change made and update
 
 <!-- [state_of_the_schema_presentation]: https://docs.google.com/presentation/d/1ldEbElaFm__jtkLoEcn2PQ-LGj1dfmdjWxDvE11eiNk/edit?usp=sharing -->
 [start_of_schema]: https://github.com/bids-standard/bids-specification/issues/466
-[bids_schema_validation_for_datatypes]: https://github.com/bids-standard/bids-validator/pull/1325
+[bids_schema_validation_for_datatypes]: https://github.com/bids-standard/legacy-validator/pull/1325
 
 [bids sprint 1 discussion]: https://bit.ly/pdx-bids-sprint
 [bids sprint 2 discussion]: https://docs.google.com/document/d/1UmcNlv5Ly9Ko6UStJBPV4UGVARjdNtZWRx9OVTLsE7Q/edit?usp=sharing


### PR DESCRIPTION
Links were broken by repo migration.