### PR TITLE
fix(dark): Replace DICOM reorganization figure in dark mode

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,8 @@ or rewriting scripts expecting certain structure.
 With the Brain  Imaging Data Structure (BIDS),
 we describe a simple and easy to adopt way of organizing neuroimaging and behavioral data.
 
-![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-black_1000x477.png)
+![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-black_1000x477.png#only-light)
+![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-white_1000x477.png#only-dark)
 
 BIDS was heavily inspired by the format used internally by the OpenfMRI repository
 that is now known as [OpenNeuro](https://openneuro.org).


### PR DESCRIPTION
This has been bugging me. Now:

## Light

![image](https://github.com/user-attachments/assets/4b329243-4789-46df-92b0-51f4b8068d73)


## Dark

![image](https://github.com/user-attachments/assets/ef308643-54e3-4d5b-958b-f1d756395143)


Sort of closes https://github.com/bids-standard/bids-website/issues/474, which was about the opposite problem.