### PR TITLE
Provide mermaid diagram of relation between BIDS schema, specification and validators

### DIFF
--- a/docs/standards/index.md
+++ b/docs/standards/index.md
@@ -16,64 +16,70 @@ You can find further information for:
 The following figure shows the relationship between the BIDS specification, validator implementations, and the BIDS schema:
 
 ```mermaid
-graph LR;
-    subgraph bids-specification-repo["<a href=https://github.com/bids-standard/bids-specification>bids-standard/bids-specification</a>"];
-        markdown
-        schema -.is interpreted by.-> bidsschematools
-    end
-
-    markdown --is interpreted by--> mkdocs
-    bidsschematools --provides MACROS for--> mkdocs
-    mkdocs --renders HTML--> specification
-
-    schema --is instance of-->bids-schema
-    bids-schema -.is implemented by.->deno & bidsschematools
-    bids-schema -.is reflected in.-> metaschema.json
-    schema.json --is instance of-->bids-schema
-
-    subgraph bids.neuroimaging.io["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
-        subgraph bids-specification-website["<a href=https://bids-specification.readthedocs.io>bids-specification.readthedocs.io</a>"];
-            specification
-            bidsschematools --compiles YAMLs as--> schema.json
-        end
-        subgraph stats-models["<a href=https://bids-standard.github.io/stats-models/>stats-models standard</a>"]
-        end
-        subgraph bids-apps["<a href=https://bids-standard.github.io/execution-spec/>bids-apps standard</a>"]
-        end
-    end
-
-    subgraph "legacy-validator @ v1.15.1";
-        regex["filename patterns"] --> Node.js
-        Node.js --> web1["<a href=https://bids-standard.github.io/legacy-validator/>web</a>"]
-        Node.js --> cli1[cli]
-    end
-    subgraph "bids-validator ≥ v2.0";
-        deno --> web["<a href=https://bids-standard.github.io/bids-validator/>web</a>"]
-        deno --> cli
-    end
-    subgraph "python-validator ≥ v1.14.7";
-        python
-        python --> library
-        python --> cli3[cli]
-    end
-
-    bids-schema -.is implemented by.->python
-
+---
+config:
+  layout: dagre
+---
+flowchart TB
+ subgraph bids-specification-repo["<a href=https://github.com/bids-standard/bids-specification>bids-standard/bids-specification</a>"]
+        markdown@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/src'>src/</a><br>markdown" }
+        bidsschematools@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/tools/schemacode'>tools/schemacode/</a><br/>bidsschematools" }
+        schema@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/src/schema'>src/schema/</a><br>YAMLs" }
+  end
+ subgraph s2["<a href=https://bids-specification.readthedocs.io>bids-specification.readthedocs.io</a>"]
+        specification["specification html"]
+        schema.json@{ label: "<a href='https://bids-specification.readthedocs.io/en/v1.10.0/schema.json'>schema.json</a>" }
+  end
+ subgraph s3["<a href=https://bids-standard.github.io/stats-models/>stats-models standard</a>"]
+  end
+ subgraph s4["<a href=https://bids-standard.github.io/execution-spec/>bids-apps standard</a>"]
+  end
+ subgraph s5["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
+        s2
+        s3
+        s4
+  end
+ subgraph subGraph5["legacy-validator @ v1.15.1"]
+        Node.js["Node.js"]
+        regex["filename patterns"]
+        web1@{ label: "<a href=\"https://bids-standard.github.io/legacy-validator/\">web</a>" }
+        cli1["cli"]
+  end
+ subgraph subGraph6["bids-validator ≥ v2.0"]
+        web@{ label: "<a href=\"https://bids-standard.github.io/bids-validator/\">web</a>" }
+        deno["deno"]
+        cli["cli"]
+  end
+ subgraph subGraph7["python-validator ≥ v1.14.7"]
+        python["python"]
+        library["library"]
+        cli3["cli"]
+  end
+    schema -. is interpreted by .-> bidsschematools
+    markdown -- is interpreted by --> mkdocs@{ label: "<a href=''>mkdocs</a>" }
+    bidsschematools -- provides MACROS for --> mkdocs
+    mkdocs -- renders HTML --> specification
+    schema -- is instance of --> bids-schema["<a href=https://bids-website.readthedocs.io/en/latest/standards/schema/index.html>BIDS Schema</a>"]
+    bids-schema -. is implemented by .-> deno & bidsschematools & python
+    bids-schema -. is reflected in .-> metaschema.json@{ label: "<a href='https://github.com/bids-standard/bids-specification/blob/master/src/metaschema.json'>metaschema.json</a><br/>JSON Schema" }
+    schema.json -- is instance of --> bids-schema & metaschema.json
+    bidsschematools -- compiles YAMLs as --> schema.json
+    regex --> Node.js
+    Node.js --> web1 & cli1
+    deno --> web & cli
+    python --> library & cli3
     specification -. is interpreted by .-> regex
-    schema.json -.is interpreted by.-> deno
-    schema.json --is instance of-->metaschema.json
-    bidsschematools --is used by--> python
-
-    markdown@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/src">src/</a><br>markdown", shape: docs}
-    schema@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/src/schema">src/schema/</a><br>YAMLs", shape: docs}
-    mkdocs@{label: "<a href="">mkdocs</a>", shape: proc}
-    bidsschematools@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/tools/schemacode">tools/schemacode/</a><br/>bidsschematools", shape: proc}
-    schema.json@{label: "<a href="https://bids-specification.readthedocs.io/en/v1.10.0/schema.json">schema.json</a>", shape: doc}
-    metaschema.json@{label: "<a href="https://github.com/bids-standard/bids-specification/blob/master/src/metaschema.json">metaschema.json</a><br/>JSON Schema", shape: doc}
-    bids-specification-repo@{label: "<a href='xxx'>bids-specification@github</a>"}
-    specification@{label: specification html}
-    bids-schema@{label: "<a href=https://bids-website.readthedocs.io/en/latest/standards/schema/index.html>BIDS Schema</a>"}
-    Node.js@{shape: subproc}
-    python@{shape: subproc}
-    deno@{shape: subproc}
+    schema.json -. is interpreted by .-> deno
+    bidsschematools -- is used by --> python
+    markdown@{ shape: docs}
+    schema@{ shape: docs}
+    bidsschematools@{ shape: proc}
+    mkdocs@{ shape: proc}
+    deno@{ shape: subproc}
+    metaschema.json@{ shape: doc}
+    schema.json@{ shape: doc}
+    Node.js@{ shape: subproc}
+    web1@{ shape: rect}
+    web@{ shape: rect}
+    python@{ shape: subproc}
 ```

--- a/docs/standards/index.md
+++ b/docs/standards/index.md
@@ -51,8 +51,8 @@ graph LR;
         deno --> web["<a href=https://bids-standard.github.io/bids-validator/>web</a>"]
         deno --> cli
     end
-    subgraph "python-validator ≥ v1.14.7"; 
-        python 
+    subgraph "python-validator ≥ v1.14.7";
+        python
         python --> library
         python --> cli3[cli]
     end
@@ -63,7 +63,7 @@ graph LR;
     schema.json -.is interpreted by.-> deno
     schema.json --is instance of-->metaschema.json
     bidsschematools --is used by--> python
-    
+
     markdown@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/src">src/</a><br>markdown", shape: docs}
     schema@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/src/schema">src/schema/</a><br>YAMLs", shape: docs}
     mkdocs@{label: "<a href="">mkdocs</a>", shape: proc}

--- a/docs/standards/index.md
+++ b/docs/standards/index.md
@@ -12,3 +12,68 @@ You can find further information for:
 -   the [BIDS schema](./schema/index.md)
 -   the [BIDS statistical model specification](.//bids_stats_model/index.md)
 -   the [BIDS apps specification](./bids_app_specification/index.md)
+
+The following figure shows the relationship between the BIDS specification, validator implementations, and the BIDS schema:
+
+```mermaid
+graph LR;
+    subgraph bids-specification-repo["<a href=https://github.com/bids-standard/bids-specification>bids-standard/bids-specification</a>"];
+        markdown
+        schema -.is interpreted by.-> bidsschematools
+    end
+
+    markdown --is interpreted by--> mkdocs
+    bidsschematools --provides MACROS for--> mkdocs
+    mkdocs --renders HTML--> specification
+
+    schema --is instance of-->bids-schema
+    bids-schema -.is implemented by.->deno & bidsschematools
+    bids-schema -.is reflected in.-> metaschema.json
+    schema.json --is instance of-->bids-schema
+
+    subgraph bids.neuroimaging.io["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
+        subgraph bids-specification-website["<a href=https://bids-specification.readthedocs.io>bids-specification.readthedocs.io</a>"];
+            specification
+            bidsschematools --compiles YAMLs as--> schema.json
+        end
+        subgraph stats-models["<a href=https://bids-standard.github.io/stats-models/>stats-models standard</a>"]
+        end
+        subgraph bids-apps["<a href=https://bids-standard.github.io/execution-spec/>bids-apps standard</a>"]
+        end
+    end
+
+    subgraph "legacy-validator @ v1.15.1";
+        regex["filename patterns"] --> Node.js
+        Node.js --> web1["<a href=https://bids-standard.github.io/legacy-validator/>web</a>"]
+        Node.js --> cli1[cli]
+    end
+    subgraph "bids-validator ≥ v2.0";
+        deno --> web["<a href=https://bids-standard.github.io/bids-validator/>web</a>"]
+        deno --> cli
+    end
+    subgraph "python-validator ≥ v1.14.7"; 
+        python 
+        python --> library
+        python --> cli3[cli]
+    end
+
+    bids-schema -.is implemented by.->python
+
+    specification -. is interpreted by .-> regex
+    schema.json -.is interpreted by.-> deno
+    schema.json --is instance of-->metaschema.json
+    bidsschematools --is used by--> python
+    
+    markdown@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/src">src/</a><br>markdown", shape: docs}
+    schema@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/src/schema">src/schema/</a><br>YAMLs", shape: docs}
+    mkdocs@{label: "<a href="">mkdocs</a>", shape: proc}
+    bidsschematools@{label: "<a href="https://github.com/bids-standard/bids-specification/tree/v1.10.0/tools/schemacode">tools/schemacode/</a><br/>bidsschematools", shape: proc}
+    schema.json@{label: "<a href="https://bids-specification.readthedocs.io/en/v1.10.0/schema.json">schema.json</a>", shape: doc}
+    metaschema.json@{label: "<a href="https://github.com/bids-standard/bids-specification/blob/master/src/metaschema.json">metaschema.json</a><br/>JSON Schema", shape: doc}
+    bids-specification-repo@{label: "<a href='xxx'>bids-specification@github</a>"}
+    specification@{label: specification html}
+    bids-schema@{label: "<a href=https://bids-website.readthedocs.io/en/latest/standards/schema/index.html>BIDS Schema</a>"}
+    Node.js@{shape: subproc}
+    python@{shape: subproc}
+    deno@{shape: subproc}
+```

--- a/docs/standards/index.md
+++ b/docs/standards/index.md
@@ -21,40 +21,41 @@ config:
   layout: dagre
 ---
 flowchart TB
- subgraph bids-specification-repo["<a href=https://github.com/bids-standard/bids-specification>bids-standard/bids-specification</a>"]
+    subgraph bids-specification-repo["<a href=https://github.com/bids-standard/bids-specification>bids-standard/bids-specification</a>"]
         markdown@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/src'>src/</a><br>markdown" }
         bidsschematools@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/tools/schemacode'>tools/schemacode/</a><br/>bidsschematools" }
         schema@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/src/schema'>src/schema/</a><br>YAMLs" }
-  end
- subgraph s2["<a href=https://bids-specification.readthedocs.io>bids-specification.readthedocs.io</a>"]
+    end
+    subgraph s2["<a href=https://bids-specification.readthedocs.io>bids-specification.readthedocs.io</a>"]
         specification["specification html"]
         schema.json@{ label: "<a href='https://bids-specification.readthedocs.io/en/v1.10.0/schema.json'>schema.json</a>" }
-  end
- subgraph s3["<a href=https://bids-standard.github.io/stats-models/>stats-models standard</a>"]
-  end
- subgraph s4["<a href=https://bids-standard.github.io/execution-spec/>bids-apps standard</a>"]
-  end
- subgraph s5["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
+    end
+    subgraph s3["<a href=https://bids-standard.github.io/stats-models/>stats-models standard</a>"]
+    end
+    subgraph s4["<a href=https://bids-standard.github.io/execution-spec/>bids-apps standard</a>"]
+    end
+    subgraph s5["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
         s2
         s3
         s4
-  end
- subgraph subGraph5["legacy-validator @ v1.15.1"]
+    end
+    subgraph subGraph5["legacy-validator @ v1.15.1"]
         Node.js["Node.js"]
         regex["filename patterns"]
         web1@{ label: "<a href=\"https://bids-standard.github.io/legacy-validator/\">web</a>" }
         cli1["cli"]
-  end
- subgraph subGraph6["bids-validator ≥ v2.0"]
+    end
+    subgraph subGraph6["bids-validator ≥ v2.0"]
         web@{ label: "<a href=\"https://bids-standard.github.io/bids-validator/\">web</a>" }
         deno["deno"]
         cli["cli"]
-  end
- subgraph subGraph7["python-validator ≥ v1.14.7"]
+    end
+    subgraph subGraph7["python-validator ≥ v1.14.7"]
         python["python"]
         library["library"]
         cli3["cli"]
-  end
+    end
+
     schema -. is interpreted by .-> bidsschematools
     markdown -- is interpreted by --> mkdocs@{ label: "<a href=''>mkdocs</a>" }
     bidsschematools -- provides MACROS for --> mkdocs
@@ -71,6 +72,7 @@ flowchart TB
     specification -. is interpreted by .-> regex
     schema.json -. is interpreted by .-> deno
     bidsschematools -- is used by --> python
+
     markdown@{ shape: docs}
     schema@{ shape: docs}
     bidsschematools@{ shape: proc}

--- a/docs/standards/index.md
+++ b/docs/standards/index.md
@@ -30,14 +30,8 @@ flowchart TB
         specification["specification html"]
         schema.json@{ label: "<a href='https://bids-specification.readthedocs.io/en/v1.10.0/schema.json'>schema.json</a>" }
     end
-    subgraph s3["<a href=https://bids-standard.github.io/stats-models/>stats-models standard</a>"]
-    end
-    subgraph s4["<a href=https://bids-standard.github.io/execution-spec/>bids-apps standard</a>"]
-    end
     subgraph s5["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
         s2
-        s3
-        s4
     end
     subgraph subGraph5["legacy-validator @ v1.15.1"]
         Node.js["Node.js"]

--- a/docs/standards/index.md
+++ b/docs/standards/index.md
@@ -21,61 +21,65 @@ config:
   layout: dagre
 ---
 flowchart TB
-    subgraph bids-specification-repo["<a href=https://github.com/bids-standard/bids-specification>bids-standard/bids-specification</a>"]
+ subgraph s6["<a href=https://github.com/bids-standard/bids-specification>bids-standard/bids-specification</a>"]
         markdown@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/src'>src/</a><br>markdown" }
         bidsschematools@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/tools/schemacode'>tools/schemacode/</a><br/>bidsschematools" }
         schema@{ label: "<a href='https://github.com/bids-standard/bids-specification/tree/v1.10.0/src/schema'>src/schema/</a><br>YAMLs" }
-    end
-    subgraph s2["<a href=https://bids-specification.readthedocs.io>bids-specification.readthedocs.io</a>"]
+  end
+ subgraph s2["<a href=https://bids-specification.readthedocs.io>bids-specification.readthedocs.io</a>"]
         specification["specification html"]
         schema.json@{ label: "<a href='https://bids-specification.readthedocs.io/en/v1.10.0/schema.json'>schema.json</a>" }
-    end
-    subgraph s5["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
+  end
+ subgraph s_jsr["<a href=https://jsr.io/@bids/schema>https://jsr.io/@bids/schema</a>"]
+        schema.json-jsr["schema.json"]
+  end
+ subgraph s5["<a href=https://bids.neuroimaging.io>bids.neuroimaging.io</a>"]
         s2
-    end
-    subgraph subGraph5["legacy-validator @ v1.15.1"]
+  end
+ subgraph subGraph5["legacy-validator @ v1.15.1"]
         Node.js["Node.js"]
         regex["filename patterns"]
         web1@{ label: "<a href=\"https://bids-standard.github.io/legacy-validator/\">web</a>" }
         cli1["cli"]
-    end
-    subgraph subGraph6["bids-validator ≥ v2.0"]
+  end
+ subgraph subGraph6["bids-validator ≥ v2.0"]
         web@{ label: "<a href=\"https://bids-standard.github.io/bids-validator/\">web</a>" }
         deno["deno"]
         cli["cli"]
-    end
-    subgraph subGraph7["python-validator ≥ v1.14.7"]
+  end
+ subgraph subGraph7["python-validator ≥ v1.14.7"]
         python["python"]
         library["library"]
         cli3["cli"]
-    end
-
+  end
     schema -. is interpreted by .-> bidsschematools
     markdown -- is interpreted by --> mkdocs@{ label: "<a href=''>mkdocs</a>" }
     bidsschematools -- provides MACROS for --> mkdocs
     mkdocs -- renders HTML --> specification
-    schema -- is instance of --> bids-schema["<a href=https://bids-website.readthedocs.io/en/latest/standards/schema/index.html>BIDS Schema</a>"]
+    schema -- is instance of --> bids-schema@{ label: "<a href=\"https://bids-website.readthedocs.io/en/latest/standards/schema/index.html\">BIDS Schema</a>" }
     bids-schema -. is implemented by .-> deno & bidsschematools & python
     bids-schema -. is reflected in .-> metaschema.json@{ label: "<a href='https://github.com/bids-standard/bids-specification/blob/master/src/metaschema.json'>metaschema.json</a><br/>JSON Schema" }
     schema.json -- is instance of --> bids-schema & metaschema.json
-    bidsschematools -- compiles YAMLs as --> schema.json
+    schema.json-jsr -- is instance of --> bids-schema & metaschema.json
+    bidsschematools -- compiles YAMLs as --> schema.json & schema.json-jsr
     regex --> Node.js
     Node.js --> web1 & cli1
     deno --> web & cli
     python --> library & cli3
     specification -. is interpreted by .-> regex
-    schema.json -. is interpreted by .-> deno
+    schema.json-jsr -. is interpreted by .-> deno
     bidsschematools -- is used by --> python
-
     markdown@{ shape: docs}
-    schema@{ shape: docs}
     bidsschematools@{ shape: proc}
-    mkdocs@{ shape: proc}
-    deno@{ shape: subproc}
-    metaschema.json@{ shape: doc}
+    schema@{ shape: docs}
     schema.json@{ shape: doc}
+    schema.json-jsr@{ shape: doc}
     Node.js@{ shape: subproc}
     web1@{ shape: rect}
     web@{ shape: rect}
+    deno@{ shape: subproc}
     python@{ shape: subproc}
+    mkdocs@{ shape: proc}
+    bids-schema@{ shape: rect}
+    metaschema.json@{ shape: doc}
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ plugins:
       module_name: macros/main
       # toggle to true if you are in CD/CI environment
       on_error_fail: true
+  - panzoom:
+      full_screen: True # default False
   - redirects:
       redirect_maps:
         # old links from the old website

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ gender_guesser
 geopy
 jinja2>=3.1.5
 markdown-it-py
-mkdocs-material[imaging]
+mkdocs-material[imaging]>=9.6.3
 mkdocs-macros-plugin
 mkdocs-open-in-new-tab
 mkdocs-redirects

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ markdown-it-py
 mkdocs-material[imaging]>=9.6.3
 mkdocs-macros-plugin
 mkdocs-open-in-new-tab
+mkdocs-panzoom-plugin
 mkdocs-redirects
 mkdocs-rss-plugin
 plotly>=5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ mkdocs-get-deps==0.2.0
     # via mkdocs
 mkdocs-macros-plugin==1.0.5
     # via -r requirements.in
-mkdocs-material==9.5.26
+mkdocs-material==9.6.5
     # via -r requirements.in
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ attrs==23.2.0
     #   referencing
 babel==2.15.0
     # via mkdocs-material
+beautifulsoup4==4.13.3
+    # via mkdocs-panzoom-plugin
 bibtexparser==1.4.1
     # via pyzotero
 bids-validator==1.14.6
@@ -113,6 +115,7 @@ mkdocs==1.6.0
     #   mkdocs-macros-plugin
     #   mkdocs-material
     #   mkdocs-open-in-new-tab
+    #   mkdocs-panzoom-plugin
     #   mkdocs-redirects
     #   mkdocs-rss-plugin
 mkdocs-get-deps==0.2.0
@@ -124,6 +127,8 @@ mkdocs-material==9.6.5
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 mkdocs-open-in-new-tab==1.0.3
+    # via -r requirements.in
+mkdocs-panzoom-plugin==0.1.3
     # via -r requirements.in
 mkdocs-redirects==1.2.1
     # via -r requirements.in
@@ -240,6 +245,8 @@ six==1.16.0
     # via python-dateutil
 smmap==5.0.1
     # via gitdb
+soupsieve==2.6
+    # via beautifulsoup4
 sqlalchemy==2.0.30
     # via pybids
 tabulate==0.9.0
@@ -256,6 +263,7 @@ tinycss2==1.3.0
     #   cssselect2
 typing-extensions==4.12.2
     # via
+    #   beautifulsoup4
     #   formulaic
     #   sqlalchemy
 tzdata==2024.1


### PR DESCRIPTION
This is based of the mermaid diagrams in the blog post we have: https://bids-website.readthedocs.io/en/latest/blog/2024/11/13/bids-validator-2.html and the goal is to give a visual depiction of relations between the components mentioned on this page and elsewhere.

- I think with this we can Close #625 

Here is a screenshot of preview.  I do agree that text is a bit small'ish, so we might want to prune it but it is quite usable and IMHO useful... May be there is a way to make it "full screen"?

<details>
<summary>version1: horizontal, harder to read, no zooming etc</summary> 

![image](https://github.com/user-attachments/assets/b4185ba0-159f-43f7-a3b6-89bd3e33bdbe)

</details>

<details>
<summary>version2: vertical</summary> 
 
![image](https://github.com/user-attachments/assets/0661de47-cfa9-43f6-ba54-bd7641eadffe)

</details>

version3: removed bids-apps and stats-models: 

![image](https://github.com/user-attachments/assets/c750b01a-a72b-4c1a-8c97-fd67cd753cbb)

TODOs 
- [ ] add into figure that schema.json is published to https://jsr.io/@bids/schema and that is what used by deno validator

