### PR TITLE
Remove "paragraph" annotation for bep045

### DIFF
--- a/data/beps/beps.yml
+++ b/data/beps/beps.yml
@@ -609,7 +609,7 @@
         family-names: Moia
     -   given-names: Sourav
         family-names: Kulkarni
-    status: |
+    status:
         - To update standards for physiological data for improved clarity and a broader range of use cases.
         - Now collecting community comments and feedback. All collaborators are welcome.
         - Original issue: [#1675](https://github.com/bids-standard/bids-specification/issues/1675)


### PR DESCRIPTION
Spotted that it was not formatted correctly on
https://bids.neuroimaging.io/extensions/beps/bep_045.html#status