### PR TITLE
Add BEP042 PR info

### DIFF
--- a/data/beps/beps.yml
+++ b/data/beps/beps.yml
@@ -557,7 +557,7 @@
         -   Original issue: https://github.com/bids-standard/bids-specification/issues/1371
     blocking:
     google_doc_created: 2023-01
-    pull_request_created: 2024-12
+    pull_request_created: 2024-12-06
     pull_request_merged:
 
 -   number: '043'


### PR DESCRIPTION
BEP042 is now in community review. We posted the call on the BIDS Google Group, Neurostars, and other venues.