### PR TITLE
BEP032 record: add more leads + fixup title

### DIFF
--- a/data/beps/beps.yml
+++ b/data/beps/beps.yml
@@ -286,7 +286,7 @@
     pull_request_merged:
 
 -   number: '032'
-    title: Animal electrophysiology
+    title: Microelectrode electrophysiology
     google_doc: https://docs.google.com/document/d/1oG-C8T-dWPqfVzL2W8HO3elWK8NIh2cOCPssRGv23n0/
     pull_request: https://github.com/bids-standard/bids-specification/pull/1705
     html_preview: https://bids-specification--1705.org.readthedocs.build/en/1705/modality-specific-files/microelectrode-electrophysiology.html
@@ -297,14 +297,22 @@
         family-names: Takerkart
     -   given-names: Benjamin
         family-names: Dichter
+    -   given-names: Yaroslav O.
+        family-names: Halchenko
+    -   given-names: Lyuba
+        family-names: Zehl
+    -   given-names: Andrew
+        family-names: Davison
     bids_maintainers:
     -   given-names: Rémi
         family-names: Gau
     status:
-    -   Decided on the new name, modalities, datatypes
+    -   Decided on the new name (not just "Animal" but "Microelectrode"), modalities, datatypes
     -   Nearly finalized added metadata
-    -   'Target: finalize & merge PR into the BIDS specs in Fall 2024'
+    -   PR compiles green, preview is available
+    -   'Target: finalize & merge PR into the BIDS specs in 2025'
     blocking:
+    -   Need to prepare example datasets
     -   Need to start thinking about derived data (spike sorted)
     google_doc_created: 2020-12
     pull_request_created: 2022-11


### PR DESCRIPTION
Title was changed to reflect that there is little of nothing specific to animals (and humans are animals too after all), and rather concerns with microelectrode electrophysiology recordings.