### PR TITLE
Fix references to BEP process and guidelines in "Collaboration" section

### DIFF
--- a/docs/collaboration/index.md
+++ b/docs/collaboration/index.md
@@ -51,5 +51,5 @@ The BIDS specification can be extended in a backwards compatible way and will ev
 These are accomplished with BIDS Extension Proposals (BEPs), which are community-driven processes.
 
 Do you want to learn more about extending BIDS to a new modality or set of data types?
-Read the [Guide](https://bids-extensions.readthedocs.io/en/latest/guide/)
-and follow the [Submission Process](https://bids-extensions.readthedocs.io/en/latest/submission/).
+Read the [BEP Process](../extensions/process.md)
+and follow the [BEP Guidelines](../extensions/guidelines.md)


### PR DESCRIPTION
See them 404ing on https://bids.neuroimaging.io/collaboration/index.html#extending-the-bids-specification