### PR TITLE
[INFRA] Update link checkeri action URL in GHA workflow file

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -39,7 +39,7 @@ jobs:
         -   name: Install dependencies and update content from submodules
             run: make all
 
-        -   uses: gaurav-nelson/github-action-markdown-link-check@v1
+        -   uses: tcort/github-action-markdown-link-check@v1
             with:
                 use-quiet-mode: yes
                 # use-verbose-mode: no


### PR DESCRIPTION
Update link checker action URL in GHA workflow file: `gaurav-nelson/github-action-markdown-link-check` is no longer maintained, and has been superseded by
`tcort/github-action-markdown-link-check`. Documentation: https://github.com/tcort/github-action-markdown-link-check