### PR TITLE
Add parts of BIDS maintainer guide to website

### DIFF
--- a/data/people/maintainers.yml
+++ b/data/people/maintainers.yml
@@ -33,3 +33,5 @@
         git: nellh
     -   name: Kimberly Ray
         git: KimberlyLRay
+    -   name: Julia-Katharina Pfarr
+        git: julia-pfarr

--- a/docs/collaboration/index.md
+++ b/docs/collaboration/index.md
@@ -1,5 +1,10 @@
 # Help make BIDS better!
 
+!!! info "Call for joining the BIDS maintainers team"
+
+    We are currently actively looking for motivated people to join the BIDS maintainers team. 
+    Please see in the section below what being a BIDS maintainer means and reach out if you'd like to join!
+
 BIDS is informed, supported, and guided by its users.
 BIDS standards are intended to change and evolve as methods, resources,
 and the needs of the BIDS community changes.
@@ -7,6 +12,8 @@ We encourage all researchers to contribute to the ongoing development of BIDS st
 be it through discussion on websites, the creation of new BIDS tools,
 or contributing to extending the BIDS specification through proposals.
 Below is a list of common resources where users can get involved in making the BIDS standard better!
+
+## Questions and issues
 
 <u>Neurostars Website</u>
 
@@ -53,3 +60,76 @@ These are accomplished with BIDS Extension Proposals (BEPs), which are community
 Do you want to learn more about extending BIDS to a new modality or set of data types?
 Read the [Guide](https://bids-extensions.readthedocs.io/en/latest/guide/)
 and follow the [Submission Process](https://bids-extensions.readthedocs.io/en/latest/submission/).
+
+## Becoming a BIDS maintainer
+
+##### Why become a maintainer?
+
+As a BIDS maintainer you may get the chance to:
+
+* Learn to work as a team
+* Bring your expertise to the BIDS maintainers group and cover technical blind spots it may have
+* Improving your technical writing skills (for example documentation)
+* Learn to work with continuous integration and deployment
+* Advise and participate in the development of BIDS extensions that are most commonly associated with a publication
+
+##### Responsibilities
+
+* Maintainers need to be loosely aware of the entire project
+  and use their knowledge to facilitate and initiate interactions
+  between different nodes of the project
+  and determine a reasonable and timely order for features to be added and issues to be resolved.
+* Maintainers direct other BIDS contributors in reviewing PRs,
+  writing clarifications to the specification, or other contributions.
+* Maintainers ensure that all contributors maintain a friendly and welcoming tone
+  to encourage productive conversations.
+* If no work team is suitable or available,
+  the final responsibility of getting the work done lies with the maintainers.
+* The development of each BIDS extension proposal should be "followed"
+  by at least one maintainer who acts as a preferential point of contact
+  between the BIDS maintainers and the BEP leads.
+
+Apart from these abstract and general responsibilities,
+maintainers within the BIDS community also need to ensure that the following tasks get done:
+
+* Keeping the
+  [Contributors wiki](https://github.com/bids-standard/bids-specification/wiki/Recent-Contributors)
+  up to date and assisting new contributors with adding their credits,
+  and performing community inquiries to ensure contributors are credited in the
+  [Contributors appendix](https://bids-specification.readthedocs.io/en/stable/appendices/contributors.html)
+    * Deciding what constitutes a contribution worth adding to the "Contributors list"
+* Preparing a monthly report to the BIDS Steering Group.
+  The monthly report is in the form of milestones, issues addressed,
+  and open issues raised in the past month and goals/plans for the next month.
+  The BIDS Steering Group may ask for additional information or propose a meeting to further discuss report items.
+  The report format and meetings are at the discretion of the BIDS Steering Group.
+
+Maintainers are not expected to individually be responsible for all the responsibilities listed.
+Rather, the responsibilities are distributed amongst the entire group.
+
+##### Organization
+
+* The group of maintainers are a group of people with the above mentioned responsibilities,
+  who commit to convene bi-weekly meetings to discuss the project.
+* One lead maintainer represents the group to other BIDS Groups, mediates disagreement among members,
+  and casts deciding votes when needed (tie break).
+  Note that the maintainers will always strive for consensus decision making, and will try to avoid resorting to voting.
+    * The lead maintainer may delegate any of their duties to another maintainer.
+    * The lead maintainer is appointed collectively by the group of maintainers, preferably through consensus.
+    * If no one else does, the lead maintainer sets the schedule for the maintainers meeting.
+* Additions to and departures from the group are negotiated collectively between the lead maintainer
+  and the new/departing members, as they involve the redistribution of duties.
+    * If a maintainer wishes to serve for a limited term, that can be arranged at the start. Otherwise, due notice is expected.
+    * See also "How to become a maintainer?" below
+
+##### How to become a maintainer?
+
+If you are interested in becoming a BIDS maintainer,
+please get in contact with an active BIDS maintainer
+(for example via opening a GitHub issue on bids-standard/bids-specification and tagging `@bids-standard/maintainers`).
+In that initial contact, it would be great if you could outline previous experience with BIDS (if any)
+and your motivation to become a maintainer, as well as particular interests for work that you would like to do.
+The BIDS maintainers will then invite you to one of the biweekly maintainers meetings (online)
+to discuss further steps and point you to the onboarding documentation (things to do).
+
+We would be happy to hear from you!

--- a/docs/collaboration/index.md
+++ b/docs/collaboration/index.md
@@ -2,7 +2,7 @@
 
 !!! info "Call for joining the BIDS maintainers team"
 
-    We are currently actively looking for motivated people to join the BIDS maintainers team. 
+    We are currently actively looking for motivated people to join the BIDS maintainers team.
     Please see in the section below what being a BIDS maintainer means and reach out if you'd like to join!
 
 BIDS is informed, supported, and guided by its users.


### PR DESCRIPTION
closes #660

- added important parts of the [BIDS maintainer guide](https://github.com/bids-standard/bids-specification/blob/master/Maintainers_Guide.md#why-become-a-maintainer) to the website 
- added an info box with a call for joining the BIDS maintainer team 