### PR TITLE
STY: Fix layout of `status` section in BEPs 44 through 46

### DIFF
--- a/data/beps/beps.yml
+++ b/data/beps/beps.yml
@@ -599,10 +599,10 @@
     bids_maintainers:
     -   given-names: Rémi
         family-names: Gau
-    update: |
-        - To harmonize and make more reusable stimuli content under stimuli/.
-        - Collecting community comments and feedback. All collaborators are welcome.
-        - Original issue: [#153](https://github.com/bids-standard/bids-specification/issues/153)
+    status:
+    -   To harmonize and make more reusable stimuli content under stimuli/.
+    -   Collecting community comments and feedback. All collaborators are welcome.
+    -   Original issue: [#153](https://github.com/bids-standard/bids-specification/issues/153)
     content:
     -   raw
     blocking:
@@ -621,10 +621,10 @@
         family-names: Moia
     -   given-names: Sourav
         family-names: Kulkarni
-    status: |
-        - To update standards for physiological data for improved clarity and a broader range of use cases.
-        - Now collecting community comments and feedback. All collaborators are welcome.
-        - Original issue: [#1675](https://github.com/bids-standard/bids-specification/issues/1675)
+    status:
+    -   To update standards for physiological data for improved clarity and a broader range of use cases.
+    -   Now collecting community comments and feedback. All collaborators are welcome.
+    -   Original issue: [#1675](https://github.com/bids-standard/bids-specification/issues/1675)
     content:
     -   raw
     blocking:
@@ -643,10 +643,10 @@
         family-names: Rokem
     -   given-names: Franco
         family-names: Pestilli
-    status: |
-        - Porting comprehensive description of streamline tractography mechanisms into specification - 10.1016/B978-0-12-817057-1.00023-8
-        - Determine appropriate resolution with TRX development - https://tee-ar-ex.github.io/trx-python/
-        - Decide on scope of BEP; e.g. whether to include tractometry, complex tract delineation
+    status:
+    -   Porting comprehensive description of streamline tractography mechanisms into specification - 10.1016/B978-0-12-817057-1.00023-8
+    -   Determine appropriate resolution with TRX development - https://tee-ar-ex.github.io/trx-python/
+    -   Decide on scope of BEP; e.g. whether to include tractometry, complex tract delineation
     content:
     -   derivative
     blocking:

--- a/data/beps/beps.yml
+++ b/data/beps/beps.yml
@@ -602,7 +602,7 @@
     status:
     -   To harmonize and make more reusable stimuli content under stimuli/.
     -   Collecting community comments and feedback. All collaborators are welcome.
-    -   Original issue: [#153](https://github.com/bids-standard/bids-specification/issues/153)
+    -   'Original issue: [#153](https://github.com/bids-standard/bids-specification/issues/153)'
     content:
     -   raw
     blocking:
@@ -624,7 +624,7 @@
     status:
     -   To update standards for physiological data for improved clarity and a broader range of use cases.
     -   Now collecting community comments and feedback. All collaborators are welcome.
-    -   Original issue: [#1675](https://github.com/bids-standard/bids-specification/issues/1675)
+    -   'Original issue: [#1675](https://github.com/bids-standard/bids-specification/issues/1675)'
     content:
     -   raw
     blocking:


### PR DESCRIPTION
Fix layout of `status` section in BEPs 44 through 46:
- Remove the pipe operator.
- Remove excessive indentation.
- Use `status` instead of `update` for BEP044


Prior to this patch set, the `status` sections of the mentioned BEPs were not being rendered (BEP044) or were being rendered (BEP045 and BEP046) as bullet lists where each item contained a single letter from the actual words on each sentence.