### PR TITLE
For merged BEPs point to their ".link" not bep page

### DIFF
--- a/templates/beps_table_md.jinja
+++ b/templates/beps_table_md.jinja
@@ -6,5 +6,5 @@
 | :--------: | :---- | :-----  | :-----  |
 {% endif %}
 {% for bep in include %}
-| [BEP {{ bep.number }}]({% if bep.type == "merged" %}{{ bep.link }}{% else %}./beps/bep_{{ bep.number }}.md{% endif %}) | {% if bep.display %} {{ bep.display }} {% else %} {{ bep.title }} {% endif %} | {% for content in bep.content %} {{ content }} {% endfor %} | {% for person in bep.leads %} {% if person.email %} [{{ person["given-names"] }} {{ person["family-names"] }}](mailto:{{ person.email }}) {% else %} {{ person["given-names"] }} {{ person["family-names"] }} {% endif %}<br>{% endfor %} |
+| [BEP {{ bep.number }}]({% if bep.link %}{{ bep.link }}{% else %}./beps/bep_{{ bep.number }}.md{% endif %}) | {% if bep.display %} {{ bep.display }} {% else %} {{ bep.title }} {% endif %} | {% for content in bep.content %} {{ content }} {% endfor %} | {% for person in bep.leads %} {% if person.email %} [{{ person["given-names"] }} {{ person["family-names"] }}](mailto:{{ person.email }}) {% else %} {{ person["given-names"] }} {{ person["family-names"] }} {% endif %}<br>{% endfor %} |
 {% endfor %}

--- a/templates/beps_table_md.jinja
+++ b/templates/beps_table_md.jinja
@@ -6,5 +6,5 @@
 | :--------: | :---- | :-----  | :-----  |
 {% endif %}
 {% for bep in include %}
-| [BEP {{ bep.number }}](./beps/bep_{{ bep.number }}.md) | {% if bep.display %} {{ bep.display }} {% else %} {{ bep.title }} {% endif %} | {% for content in bep.content %} {{ content }} {% endfor %} | {% for person in bep.leads %} {% if person.email %} [{{ person["given-names"] }} {{ person["family-names"] }}](mailto:{{ person.email }}) {% else %} {{ person["given-names"] }} {{ person["family-names"] }} {% endif %}<br>{% endfor %} |
+| [BEP {{ bep.number }}]({% if bep.type == "merged" %}{{ bep.link }}{% else %}./beps/bep_{{ bep.number }}.md{% endif %}) | {% if bep.display %} {{ bep.display }} {% else %} {{ bep.title }} {% endif %} | {% for content in bep.content %} {{ content }} {% endfor %} | {% for person in bep.leads %} {% if person.email %} [{{ person["given-names"] }} {{ person["family-names"] }}](mailto:{{ person.email }}) {% else %} {{ person["given-names"] }} {{ person["family-names"] }} {% endif %}<br>{% endfor %} |
 {% endfor %}


### PR DESCRIPTION
Most (all?) of them do no longer have such a page

Discovered by clicking on links in https://bids.neuroimaging.io/extensions/beps.html#merged-beps and just getting 404s.

edit: the same apparently happens to https://bids.neuroimaging.io/extensions/beps.html#closed-beps , and this PR fixes them as well!