### PR TITLE
Change wording to point to not limit BIDS to "neuroimaging"

### DIFF
--- a/docs/collaboration/governance.md
+++ b/docs/collaboration/governance.md
@@ -14,7 +14,7 @@ The goal of this document is to clearly describe how BIDS is maintained and grow
 ### A. Project Summary
 
 The Brain Imaging Data Structure (BIDS) is a standard specifying the
-description of neuroimaging data in a filesystem hierarchy and of the
+description of neural and associated data in a filesystem hierarchy and of the
 metadata associated with the imaging data.
 The current edition of the standard is available in
 [HTML][specification] with all
@@ -37,7 +37,7 @@ In the transitional period after Chris Gorgolewski's departure in early 2019
 and before the community's acceptance of the present governance in late 2019,
 the project was managed and maintained by Franklin Feingold, Stefan Appelhoff, and the Poldrack Lab at Stanford.
 BIDS has advanced under the direction and effort of its contributors,
-the community of researchers that appreciate the value of standardizing neuroimaging data to facilitate sharing and analysis.
+the community of researchers that appreciate the value of standardizing neural and associated data to facilitate sharing and analysis.
 The project is multifaceted and depends on contributors for:
 specification development and maintenance,
 [BIDS Extension Proposals (BEPs)](../extensions/beps.md),
@@ -69,19 +69,19 @@ overlap.
 
 ### B. BIDS Mission Statement
 
-The goal of BIDS is to make neuroimaging data more accessible,
+The goal of BIDS is to make neural and associated data more accessible,
 shareable, and usable by researchers. To achieve this goal, BIDS seeks
 to develop a simple and intuitive way to organize and describe
-neuroimaging and associated data. BIDS has three foundational
+neural and associated data. BIDS has three foundational
 principles:
 
 1.  To minimize complexity and facilitate adoption, reuse existing
     methods and technologies whenever possible.
 
-1.  Tackle 80% of the most commonly used neuroimaging data, derivatives,
+1.  Tackle 80% of the most commonly used neural data, derivatives,
     and models (inspired by the pareto principle).
 
-1.  Adoption by the global neuroimaging community and their input during
+1.  Adoption by the global neuroscience community and their input during
    the creation of the specification is critical for the success of the project.
 
 ## 3. Leadership structure

--- a/docs/datasets/index.md
+++ b/docs/datasets/index.md
@@ -1,5 +1,5 @@
 # Datasets
-BIDS compliant data can be found under many of the common neuroimaging data sharing
+BIDS compliant data can be found under many of the common neural data sharing
 websites/databases. Below are some links to BIDS compliant data. Sourcedata (pre-BIDS)
 are sometimes also available and these data can be used to test (or to build tutorials)
 of how source data are converted to BIDS.

--- a/docs/getting_started/bids_apps/index.md
+++ b/docs/getting_started/bids_apps/index.md
@@ -3,7 +3,7 @@ layout: post
 title: What is a BIDS App?
 ---
 
-A BIDS App is a container image capturing a neuroimaging pipeline that takes a BIDS formatted dataset as input.
+A BIDS App is a container image capturing a pipeline that takes a BIDS formatted dataset as input.
 
 Each BIDS App has the same core set of command line arguments,
 making them easy to run and integrate into automated platforms.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -1,5 +1,5 @@
 # Unsure how to get started using BIDS with your current data?
 
-BIDS, at its core, is a set of guidelines for naming and organizing neuroimaging files that is intended to standardize many processes in neuroimaging research and foster a data ecosystem that makes collaboration and data sharing easy. For newcomers to BIDS standards, getting used to these file standards can be overwhelming, especially when considering organizational changes and file edits that are needed to convert datasets into BIDS format.
+BIDS, at its core, is a set of guidelines for naming and organizing neural and associated files that is intended to standardize many processes in neuroscience research and foster a data ecosystem that makes collaboration and data sharing easy. For newcomers to BIDS standards, getting used to these file standards can be overwhelming, especially when considering organizational changes and file edits that are needed to convert datasets into BIDS format.
 
 The following resources were developed to help newcomers to the BIDS standards learn how BIDS data are organized, provide information through publications and presentations, and provide a set of tutorials that are intended to help you get started using BIDS.

--- a/docs/getting_started/resources/glossary.md
+++ b/docs/getting_started/resources/glossary.md
@@ -33,7 +33,7 @@ One continuous block of a scan.
 
 #### BIDS
 
-Brain Imaging Data Structure - a standardized way to organize your and associated data.
+Brain Imaging Data Structure - a standardized way to organize your neural and associated data.
 
 ### C
 

--- a/docs/getting_started/resources/glossary.md
+++ b/docs/getting_started/resources/glossary.md
@@ -33,7 +33,7 @@ One continuous block of a scan.
 
 #### BIDS
 
-Brain Imaging Data Structure - a standardized way to organize your neuroimaging data.
+Brain Imaging Data Structure - a standardized way to organize your and associated data.
 
 ### C
 

--- a/docs/impact/index.md
+++ b/docs/impact/index.md
@@ -51,7 +51,7 @@ in the neuroimaging research landscape and continues to expand every day. A more
 history and discussion about the future of the BIDS landscape can be found in this
 [recent publication](https://pmc.ncbi.nlm.nih.gov/articles/PMC10516110/).
 
-The BIDS standard continues to be adopted by a larger share of the community each year.
+The BIDS standard continues to be adopted by a larger share of the wider neuroscience community each year.
 We have seen a large and growing number of visitors to the BIDS website. A large number of
 BIDS users also continue to explore the BIDS Specification and contribute to the community every month.
 

--- a/docs/impact/measuring.md
+++ b/docs/impact/measuring.md
@@ -17,7 +17,7 @@ https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#snippets-
 
 ## Citation Count
 
-As the adoption of the BIDS standard across neuroimaging datasets has grown, so have
+As the adoption of the BIDS standard across neural datasets has grown, so have
 citations for work that uses BIDS data and BIDS apps. To aid in searching for publications
 relevant to the BIDS standard, we have included some examples of BIDS references that are
 centralized in a [zotero group](https://www.zotero.org/groups/5111637/bids)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,13 @@
 title: BIDS
 ---
 
-Neuroimaging experiments result in complex data that can be arranged in many different ways.
-For a long time, there was no consensus how to organize and share
-data obtained in neuroimaging experiments.
+Experiments in neuroscience result in complex data that can be arranged in many different ways.
+For a long time, there was no consensus how to organize and share experimental data.
 Even two researchers working in the same lab could opt to arrange their data in a different way.
 Lack of consensus (or a standard) leads to misunderstandings and time wasted on rearranging data
 or rewriting scripts expecting certain structure.
 With the Brain  Imaging Data Structure (BIDS),
-we describe a simple and easy to adopt way of organizing neuroimaging and behavioral data.
+we describe a simple and easy to adopt way of organizing neural and associated, such as behavioral, data.
 
 ![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-black_1000x477.png#only-light)
 ![BIDS-folder-organization](./assets/img/dicom-reorganization-transparent-white_1000x477.png#only-dark)
@@ -36,7 +35,7 @@ and still an adapting, growing tool, the greater the community, the better it wi
 
 ## Specification vs. Ecosystem
 
-Since the inception of the BIDS specification that documents how to organize neuroimaging data,
+Since the inception of the BIDS specification that documents how to organize neural and associated data,
 a large ecosystem of tools and resources has evolved around BIDS.
 
 A few of the key elements of this ecosystem are
@@ -45,7 +44,7 @@ the [BIDS specification](http://bids-specification.readthedocs.io/) with the nit
 the [starter kit](./getting_started/index.md) with a simple explanation how to work with it,
 <!-- markdown-link-check-enable -->
 the [BIDS validator](https://github.com/bids-standard/bids-validator) to automatically check datasets for adherence to the specification,
-[BIDS Apps](https://doi.org/10.1371/journal.pcbi.1005209), a collection of portable neuroimaging pipelines that understand BIDS datasets,
+[BIDS Apps](https://doi.org/10.1371/journal.pcbi.1005209), a collection of portable pipelines that understand BIDS datasets,
 and [OpenNeuro][openneuro] as a database for BIDS formatted datasets.
 
 A non-exhaustive list of further tools can be found in the [tools](./tools/index.md) section.


### PR DESCRIPTION
BIDS has expanded to cover various data types which are not strictly "imaging" but relate to neural data or expressions of neural processes: e.g. purely behavioral datasets, ongong work on BEP032 on microelectrodes arrays, etc.  As such, we should start moving away from limiting description of BIDS only to neuroimaging.  This would be the first step in a sequence of such changes and I think it does not need tobe  contingent on any other change.

Mostly it is a change of "neuroimaging" to "neural" when refers to data type, and "neuroscience" when relates to science/community.