### PR TITLE
Remove example of `rawdata/` at the top-level of a BIDS dataset

### DIFF
--- a/docs/getting_started/folders_and_files/derivatives.md
+++ b/docs/getting_started/folders_and_files/derivatives.md
@@ -217,16 +217,4 @@ Note that the `sourcedata/` and `derivatives/` subdirectories constitute dataset
 Any contents of these directories may be validated independently,
 but their contents must not affect the interpretation of the nested or containing datasets.
 
-Unnested datasets are also possible. For example:
-
-```bash
-my_study/
-  raw_data/
-    sub-01/
-    ...
-  derivatives/
-    preprocessed/
-    analysis/
-```
-
 <!-- TODO derivatives JSON -->


### PR DESCRIPTION
As a follow up to https://github.com/bids-standard/bids-specification/pull/1741, it looks like `rawdata/` at the top-level is no longer valid.


```
[BIDS.NOT_INCLUDED] ~/linc/000005/rawdata — Files with such naming scheme are not part of BIDS specification. This error is most commonly caused by typos in file names that make them not BIDS compatible. Please consult the specification and make sure your files are named correctly. If this is not a file naming issue (for example when including files not yet covered by the BIDS specification) you should include a ".bidsignore" file in your dataset (see https://github.com/bids-standard/bids-validator#bidsignore for details). Please note that derived (processed) data should be placed in /derivatives folder and source data (such as DICOMS or behavioural logs in proprietary formats) should be placed in the /sourcedata folder.
```

cc @dstansby @satra @balbasty @ayendiki @yarikoptic 