### PR TITLE
chore: Sync BEP information with spec CITATION.cff

### DIFF
--- a/data/beps/beps.yml
+++ b/data/beps/beps.yml
@@ -550,9 +550,9 @@
         family-names: Shirazi
     bids_maintainers:
     status:
-        -   Community comments and feedback are being collected (April 2025)
-        -   Approved on May 2024, inviting collaborators (please join)
-        -   Original issue: https://github.com/bids-standard/bids-specification/issues/1371
+    -   Community comments and feedback are being collected (April 2025)
+    -   Approved on May 2024, inviting collaborators (please join)
+    -   Original issue: https://github.com/bids-standard/bids-specification/issues/1371
     blocking:
     google_doc_created: 2023-01
     pull_request_created: 2024-12-06

--- a/data/beps/beps.yml
+++ b/data/beps/beps.yml
@@ -132,7 +132,6 @@
     leads:
     -   given-names: Eugene P.
         family-names: Duff
-        email: eugene.duff@paediatrics.ox.ac.uk
     bids_maintainers:
     status:
     -   specified different formats for dense and sparse matrices
@@ -181,8 +180,8 @@
         family-names: Hermes
     -   given-names: Mainak
         family-names: Jas
-    -   given-names: Julia
-        family-names: Guiomar Niso Galán
+    -   given-names: Guiomar
+        family-names: Niso
     -   given-names: Robert
         family-names: Oostenveld
     -   given-names: Cyril
@@ -398,7 +397,7 @@
     content:
     -   raw
     leads:
-    -   given-names: Eric
+    -   given-names: Eric A.
         family-names: Earl
     -   given-names: Samuel
         family-names: Guay
@@ -407,7 +406,7 @@
     -   given-names: Arshitha
         family-names: Basavaraj
     bids_maintainers:
-    -   given-names: Eric
+    -   given-names: Eric A.
         family-names: Earl
     status:
     -   PR nearly ready to integrate with modality agnostic files sections.
@@ -455,7 +454,6 @@
         family-names: Herholz
     -   given-names: Eugene P.
         family-names: Duff
-        email: eugene.duff@paediatrics.ox.ac.uk
     -   given-names: Anthony
         family-names: Galassi
     bids_maintainers:
@@ -503,7 +501,7 @@
     -   given-names: Jean-Charles
         family-names: Mariani
     -   given-names: Samuel
-        family-names: Diebolt
+        family-names: Le Meur-Diebolt
     -   given-names: Thomas
         family-names: Deffieux
     bids_maintainers:
@@ -641,7 +639,7 @@
     display: Tractography
     google_doc: https://docs.google.com/document/d/1ubDQ2RhgjnfGqoeukzEkPV9YEHhfYMERrj7-3b0c2HI/edit
     leads:
-    -   given-names: Robert
+    -   given-names: Robert E.
         family-names: Smith
     -   given-names: Ariel
         family-names: Rokem

--- a/tools/ci/validate_people.py
+++ b/tools/ci/validate_people.py
@@ -69,7 +69,9 @@ def main(files_to_check):
                     has_email = True
                 else:
                     color = "yellow" if has_email else "red"
-                    print(f"      [{color}]no email in specification/CITATION.cff.")
+                    print(
+                        f"      [{color}]no email in specification/CITATION.cff."
+                    )
 
                 if email["conflicting"]:
                     return_code = 1

--- a/tools/ci/validate_people.py
+++ b/tools/ci/validate_people.py
@@ -57,10 +57,10 @@ def main(files_to_check):
                 if status in ["not found", "skip"]:
                     continue
 
-                if email["in_bids_wesbite"]:
+                if email["in_bids_website"]:
                     return_code = 1
                     print(
-                        "      [red]email should be in specification/CITATION.cff not in bids-wesbite data."
+                        "      [red]email should be in specification/CITATION.cff not in bids-website data."
                     )
 
                 if not email["in_citation_cff"]:
@@ -72,7 +72,7 @@ def main(files_to_check):
                     print(
                         "      [red]conflicting emails found:\n",
                         f"      [red]  - '{email["in_citation_cff"]}' in specification/CITATION.cff\n"
-                        f"      [red]   - '{email["in_bids_wesbite"]}' bids-wesbite data.",
+                        f"      [red]   - '{email["in_bids_website"]}' bids-website data.",
                     )
 
     sys.exit(return_code)
@@ -83,7 +83,7 @@ def check_lead(citation, lead):
     status = "not found"
 
     email = {
-        "in_bids_wesbite": lead.get("email", False),
+        "in_bids_website": lead.get("email", False),
         "in_citation_cff": False,
         "conflicting": False,
     }
@@ -99,7 +99,7 @@ def check_lead(citation, lead):
             email["in_citation_cff"] = contributor.get("email", False)
 
             if (
-                email["in_bids_wesbite"]
+                email["in_bids_website"]
                 and email["in_citation_cff"]
                 and lead["email"] != contributor["email"]
             ):

--- a/tools/ci/validate_people.py
+++ b/tools/ci/validate_people.py
@@ -37,6 +37,8 @@ def main(files_to_check):
 
         for bep in data:
 
+            has_email = False
+
             print(f'[blue]{bep["number"]} {bep["title"]}')
             for lead in bep["leads"]:
 
@@ -63,9 +65,11 @@ def main(files_to_check):
                         "      [red]email should be in specification/CITATION.cff not in bids-website data."
                     )
 
-                if not email["in_citation_cff"]:
-                    return_code = 1
-                    print("      [red]no email in specification/CITATION.cff.")
+                if email["in_citation_cff"]:
+                    has_email = True
+                else:
+                    color = "yellow" if has_email else "red"
+                    print(f"      [{color}]no email in specification/CITATION.cff.")
 
                 if email["conflicting"]:
                     return_code = 1
@@ -74,6 +78,8 @@ def main(files_to_check):
                         f"      [red]  - '{email["in_citation_cff"]}' in specification/CITATION.cff\n"
                         f"      [red]   - '{email["in_bids_website"]}' bids-website data.",
                     )
+
+            return_code |= not has_email
 
     sys.exit(return_code)
 


### PR DESCRIPTION
Down to 4 missing citations:

```
󰅂 uv run tools/ci/validate_people.py | grep '^0|NOT|no email' | grep '^ ' -B1
    13-	032 Microelectrode electrophysiology
    14:	      no email in specification/CITATION.cff.
    15:	    NOT FOUND Andrew Davison
--
    28-	045 Peripheral Physiological Recordings
    29:	    NOT FOUND Mary Miedema
    30:	    NOT FOUND Stefano Moia
    31:	    NOT FOUND Sourav Kulkarni
```

I believe these folks are:

@apdavison @m-miedema @smoia @Sourav-Kulkarni

Also @lzehl is missing an email in the main spec CITATION.cff, but I relaxed the check to only be an error if there are no BEP leads with emails.

