### PR TITLE
Create .add-doc-link.yaml

### DIFF
--- a/.github/workflows/.add-doc-link.yaml
+++ b/.github/workflows/.add-doc-link.yaml
@@ -1,16 +1,17 @@
+---
 name: Read the Docs PR preview
 on:
-  pull_request_target:
-    types:
-      - opened
+    pull_request_target:
+        types:
+        -   opened
 
 permissions:
-  pull-requests: write
+    pull-requests: write
 
 jobs:
-  pr-preview-link:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: readthedocs/actions/preview@v1
-        with:
-          project-slug: "bids-website"
+    pr-preview-link:
+        runs-on: ubuntu-latest
+        steps:
+        -   uses: readthedocs/actions/preview@v1
+            with:
+                project-slug: bids-website


### PR DESCRIPTION
adds a preview link for the docs on the bottom of the PR description, easier to find for unexperienced reviewers/contributors

closes #662 