### PR TITLE
ENH: Add PETPrep tool for PET data preprocessing

### DIFF
--- a/data/tools/apps.yml
+++ b/data/tools/apps.yml
@@ -433,6 +433,7 @@ apps:
     dh: nipreps/petprep
     ds_type:
     -   raw
+    -   derivative
     datatype:
     -   anat
     -   pet


### PR DESCRIPTION
Added PETPrep BIDS application entry with details for preprocessing PET data.

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--740.org.readthedocs.build/en/740/

<!-- readthedocs-preview bids-website end -->