### PR TITLE
Adding bclenet as maintainer

### DIFF
--- a/data/people/maintainers.yml
+++ b/data/people/maintainers.yml
@@ -14,6 +14,8 @@
     members:
     -   name: Ross Blair
         git: rwblair
+    -   name: Boris Clénet
+        git: bclenet
     -   name: Eric Earl
         git: ericearl
     -   name: Anthony Galassi


### PR DESCRIPTION
Updating `data/people/maintainers.yml` to add bclenet as maintainer.

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--744.org.readthedocs.build/en/744/

<!-- readthedocs-preview bids-website end -->