### PR TITLE
Add NFDI4BIOIMAGE funding source details

### DIFF
--- a/data/grants.yml
+++ b/data/grants.yml
@@ -67,4 +67,5 @@
 
 -   source: NFDI4BIOIMAGE - 501864659 (DFG, German Research Foundation)
     url: https://www.dfg.de/en/research-funding/funding-initiative/nfdi
-    contribution: National research data infrastrustructure initiative for biomedial imaging, contributed to specification and documentation especially of the microscopy BEP.
+    contribution: National research data infrastrustructure initiative for biomedial imaging, contributed to specification and documentation especially
+        of the microscopy BEP.


### PR DESCRIPTION
I propose to add a grant entry for the German NFDI4Bioimage project, through which contributions to reviewing BIDS and specifying the microscopy BEP were made.

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--760.org.readthedocs.build/en/760/

<!-- readthedocs-preview bids-website end -->