### PR TITLE
[BEP process] Add optional step: update the website

### DIFF
--- a/docs/extensions/process.md
+++ b/docs/extensions/process.md
@@ -177,8 +177,8 @@ proposed_bep_review -- positive evaluation --> merged_bep
 
 In rare cases, it may be necessary to update:
 
-*   the BIDS validator to properly validate new content from a BEP;
-*   the BIDS website.
+-   the BIDS validator to properly validate new content from a BEP;
+-   the BIDS website.
 
 #### SUGGESTED deliverables
 


### PR DESCRIPTION
Some BEPs might require to update the BIDS website.
This PR proposes this as an optional deliverable of the BEP process.

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--761.org.readthedocs.build/en/761/

<!-- readthedocs-preview bids-website end -->