### PR TITLE
Add nwb2bids converter for microelectrode electrophysiology data

### DIFF
--- a/data/tools/converters.yml
+++ b/data/tools/converters.yml
@@ -620,6 +620,25 @@
     comment: Use this package as a command line to organize your Nifti dataset into BIDS.
     license: GPL-3.0
 
+-   name: nwb2bids
+    repo_url: https://github.com/con/nwb2bids
+    status: active
+    data_types:
+    -   microephys
+    expected_input:
+    -   NWB
+    language:
+    -   Python
+    distribution:
+    -   name: pypi
+        url: https://pypi.org/project/nwb2bids
+    documentation: https://nwb2bids.readthedocs.io/
+    comment: |
+        Reorganizes NWB (Neurodata Without Borders) files into a BIDS directory
+        layout, supporting microelectrode electrophysiology data (ecephys/icephys)
+        per BEP032.
+    license: MIT
+
 -   name: phys2bids
     repo_url: https://github.com/physiopy/phys2bids
     status: active

--- a/docs/tools/converters.md
+++ b/docs/tools/converters.md
@@ -27,12 +27,6 @@ Converters for processing EEG, MEEG, and/or iEEG data.
 
 {{ MACROS___generate_converter_table(file="converters.yml", data_type="EEG") }}
 
-## Microelectrode Electrophysiology Converters
-
-Converters for processing microelectrode electrophysiology data (ecephys/icephys).
-
-{{ MACROS___generate_converter_table(file="converters.yml", data_type="microephys") }}
-
 ## fNIRS Converters
 
 Converters for processing fNIRS data.
@@ -59,3 +53,14 @@ Not exactly BIDS converters but are common tools that can used by other BIDS
 converters.
 
 {{ MACROS___generate_converter_table(file="converters.yml", data_type="MISC") }}
+
+## Experimental Converters
+
+The converters listed below are considered 'experimental',
+usually because they relate to BIDS extensions that have not yet been approved.
+
+### Microelectrode Electrophysiology Converters
+
+Converters for processing microelectrode electrophysiology data (ecephys/icephys).
+
+{{ MACROS___generate_converter_table(file="converters.yml", data_type="microephys") }}

--- a/docs/tools/converters.md
+++ b/docs/tools/converters.md
@@ -27,6 +27,12 @@ Converters for processing EEG, MEEG, and/or iEEG data.
 
 {{ MACROS___generate_converter_table(file="converters.yml", data_type="EEG") }}
 
+## Microelectrode Electrophysiology Converters
+
+Converters for processing microelectrode electrophysiology data (ecephys/icephys).
+
+{{ MACROS___generate_converter_table(file="converters.yml", data_type="microephys") }}
+
 ## fNIRS Converters
 
 Converters for processing fNIRS data.


### PR DESCRIPTION
Add con/nwb2bids to converters list and a new "Microelectrode Electrophysiology Converters" section in converters.md. nwb2bids reorganizes NWB files into BIDS layout, supporting ecephys/icephys data per BEP032.

This was inspired by looking into @neuromechanist 's OSA framework and thinking how it could even potentially figure out to suggest nwb2bids? ;)

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--797.org.readthedocs.build/en/797/

<!-- readthedocs-preview bids-website end -->