### PR TITLE
Add direct link to BIDS steering and BIDS maintainers sections

### DIFF
--- a/docs/collaboration/index.md
+++ b/docs/collaboration/index.md
@@ -17,8 +17,6 @@ See [Governance and Decision Making](governance.md) for more details on BIDS gov
     We are currently actively looking for motivated people to join the BIDS maintainers team.
     Please see in the section below what being a BIDS maintainer means and reach out if you'd like to join!
 
-
-
 Below is a list of common resources where users can get involved in making the BIDS standard better!
 
 ## Questions and issues


### PR DESCRIPTION
This PR is a followup to #798 to add a direct link from the landing page of the Collaboration section to the subsection on the governance subpage that relates to BIDS maintainers and BIDS steering. 

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--799.org.readthedocs.build/en/799/

<!-- readthedocs-preview bids-website end -->