### PR TITLE
[FIX] remove include to a missing file

### DIFF
--- a/docs/extensions/process.md
+++ b/docs/extensions/process.md
@@ -264,12 +264,7 @@ More details on how to proceed are described below.
     To obtain a number for your BEP open [a pull request](https://github.com/bids-standard/bids-website/pulls)
     to the [website GitHub repository][bids_website_gh]
     where you provide information about your BEP
-    by updating the file [`data/beps/beps.yml`](https://github.com/bids-standard/bids-website/blob/main/data/beps/beps.yml)
-    using the following template:
-
-    ```yaml
-    --8<-- ".github/PULL_REQUEST_TEMPLATE/bep_template.yml"
-    ```
+    by updating the file [`data/beps/beps.yml`](https://github.com/bids-standard/bids-website/blob/main/data/beps/beps.yml).
 
     !!! note
 


### PR DESCRIPTION
Should fix this issue of a missing file view on this page

https://bids.neuroimaging.io/extensions/process.html#starting-your-bep

<img width="849" height="255" alt="image" src="https://github.com/user-attachments/assets/5aa40a96-fc8d-4adc-ad3c-94c37f8ed5d1" />


<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--801.org.readthedocs.build/en/801/

<!-- readthedocs-preview bids-website end -->