### PR TITLE
Remove twitter link from contact page

### DIFF
--- a/docs/contact/index.md
+++ b/docs/contact/index.md
@@ -57,7 +57,6 @@ Some example questions that have already been answered include:
 
     -   [:simple-bluesky: Bluesky](https://bsky.app/profile/bidsstandard.bsky.social/)
     -   [:simple-mastodon: Mastodon](https://fosstodon.org/@bidsstandard/)
-    -   [:simple-x: X](https://x.com/BIDSstandard)
     -   [:simple-youtube: YouTube](https://www.youtube.com/channel/UCxZUcYfd_nvIVWAbzRB1tlw)
     -   [:simple-instagram: Instagram](https://www.instagram.com/bidsstandard)
     -   Listen to our [podcast](https://anchor.fm/bids-maintenance)


### PR DESCRIPTION
We do not post to Twitter, we just squat the name.

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--850.org.readthedocs.build/en/850/

<!-- readthedocs-preview bids-website end -->