### PR TITLE
Add SpinePrep to the BIDS Apps list

### DIFF
--- a/data/tools/apps.yml
+++ b/data/tools/apps.yml
@@ -599,3 +599,13 @@ apps:
     branch: main
     ci: aws_codebuild
     badge: https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiYzdXV0tYSkQzTVNkcG04cHA2S055UXlKRlZTU1VONThUMVRoZVcwU3l1aHFhdVBlNDNaRGVCYzdWM1Q0WjYzQ1lRU2ZTSHpmSERPWFRkVXVyb3k3RTZBPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRCZFFIQnNGT2lKcDA1VG4iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main
+-   gh: SpinePrep/SpinePrep
+    status: active
+    ds_type:
+    -   raw
+    datatype:
+    -   anat
+    -   func
+    description: SpinePrep is a containerised BIDS-App for reproducible, QC-first preprocessing of human spinal-cord fMRI, automating the recommended cord-fMRI recipe (SCT, FSL, PAM50) with per-vertebral-level quality control.
+    branch: main
+    ci: gh

--- a/data/tools/apps.yml
+++ b/data/tools/apps.yml
@@ -606,6 +606,7 @@ apps:
     datatype:
     -   anat
     -   func
-    description: SpinePrep is a containerised BIDS-App for reproducible, QC-first preprocessing of human spinal-cord fMRI, automating the recommended cord-fMRI recipe (SCT, FSL, PAM50) with per-vertebral-level quality control.
+    description: SpinePrep is a containerised BIDS-App for reproducible, QC-first preprocessing of human spinal-cord fMRI, automating the recommended cord-fMRI
+        recipe (SCT, FSL, PAM50) with per-vertebral-level quality control.
     branch: main
     ci: gh


### PR DESCRIPTION
Adds [SpinePrep](https://spineprep.com) to data/tools/apps.yml — an open, containerised BIDS-App for reproducible, QC-first preprocessing of human spinal-cord fMRI (repo: https://github.com/SpinePrep/SpinePrep, on PyPI as spineprep). It automates the recommended cord-fMRI recipe (SCT, FSL, PAM50) with per-vertebral-level quality control. No Docker Hub image is listed by design — SpinePrep ships as a build recipe.

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--871.org.readthedocs.build/en/871/

<!-- readthedocs-preview bids-website end -->