### PR TITLE
[FIX] fix typo to link to eyetracking BEP

### DIFF
--- a/data/beps/beps_completed.yml
+++ b/data/beps/beps_completed.yml
@@ -164,7 +164,7 @@
 -   number: '020'
     title: Eye Tracking including Gaze Position and Pupil Size
     display: Eye Tracking
-    linkt: https://bids-specification.readthedocs.io/en/stable/modality-specific-files/physiological-recordings.html#eye-tracking
+    link: https://bids-specification.readthedocs.io/en/stable/modality-specific-files/physiological-recordings.html#eye-tracking
     content:
     -   raw
     leads:


### PR DESCRIPTION
- closes #889 

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--891.org.readthedocs.build/en/891/

<!-- readthedocs-preview bids-website end -->