### PR TITLE
Add AutoHS to BIDS Apps listing

### DIFF
--- a/data/tools/apps.yml
+++ b/data/tools/apps.yml
@@ -297,6 +297,18 @@ apps:
 
 # apps hosted somewhere else
 # sorted alphabetically by DockerHub (dh)
+-   gh: phindagijimana/AutoHS
+    status: active
+    dh: autohs/autohs
+    ci: gh
+    branch: main
+    workflow: CI
+    ds_type:
+    -   raw
+    datatype:
+    -   anat
+    description: Automated hippocampal sclerosis workflow from T1w MRI: segmentation, hippocampal volumes, asymmetry index, and clinical reports.
+
 -   gh: cpp-lln-lab/bidsMReye
     status: active
     dh: cpplab/bidsmreye

--- a/data/tools/apps.yml
+++ b/data/tools/apps.yml
@@ -307,7 +307,9 @@ apps:
     -   raw
     datatype:
     -   anat
-    description: Automated hippocampal sclerosis workflow from T1w MRI: segmentation, hippocampal volumes, asymmetry index, and clinical reports.
+    description: >-
+        Automated hippocampal sclerosis workflow from T1w MRI: segmentation,
+        hippocampal volumes, asymmetry index, and clinical reports.
 
 -   gh: cpp-lln-lab/bidsMReye
     status: active


### PR DESCRIPTION
Adds AutoHS (`phindagijimana/AutoHS`) to the BIDS Apps tool listing.

AutoHS is a BIDS App for hippocampal sclerosis screening from T1w MRI. It performs
FreeSurfer or FastSurfer segmentation, hippocampal volume extraction, asymmetry
index computation, and clinical reporting with BIDS Derivatives outputs.

- GitHub: https://github.com/phindagijimana/AutoHS
- Docker Hub: `autohs/autohs`
- Documentation: https://autohs.readthedocs.io
- CI: GitHub Actions workflow `CI` on branch `main`

Made with [Cursor](https://cursor.com)

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--905.org.readthedocs.build/en/905/

<!-- readthedocs-preview bids-website end -->