### PR TITLE
[ENH] Add PennLINC/simbids to bids-apps registry

### DIFF
--- a/data/tools/apps.yml
+++ b/data/tools/apps.yml
@@ -529,6 +529,20 @@ apps:
     ci: circleci
     branch: main
 
+-   gh: PennLINC/simbids
+    status: active
+    dh: pennlinc/simbids
+    ds_type:
+    -   raw
+    -   derivative
+    datatype:
+    -   anat
+    -   func
+    -   dwi
+    description: Simulate BIDS MRI data and BIDS Derivatives for CI testing
+    ci: gh
+    branch: main
+
 -   gh: poldracklab/fitlins
     status: active
     dh: poldracklab/fitlins


### PR DESCRIPTION
SimBIDS simulates BIDS MRI data and BIDS Derivatives for CI testing (see https://github.com/PennLINC/simbids and the BABS walkthrough at https://pennlinc-babs.readthedocs.io/en/0.5.3/walkthrough.html).

there is also outstanding PR on improving description but that shouldn't stop this PR:

- https://github.com/PennLINC/simbids/pull/22

<!-- readthedocs-preview bids-website start -->
----
📚 Documentation preview 📚: https://bids-website--906.org.readthedocs.build/en/906/

<!-- readthedocs-preview bids-website end -->